### PR TITLE
feat: display sub-agent names in tree view

### DIFF
--- a/services/dashboard/src/utils/conversation-graph.ts
+++ b/services/dashboard/src/utils/conversation-graph.ts
@@ -16,6 +16,7 @@ function escapeHtml(str: string): string {
 export interface ConversationNode {
   id: string
   label: string
+  displayName?: string // Sub-agent name or other display override
   timestamp: Date
   branchId: string
   parentId?: string
@@ -51,6 +52,7 @@ export interface LayoutNode {
   branchId: string
   timestamp: Date
   label: string
+  displayName?: string // Sub-agent name or other display override
   tokens: number
   model: string
   hasError: boolean
@@ -272,6 +274,7 @@ function calculateReversedLayout(
         branchId: node.branchId,
         timestamp: node.timestamp,
         label: node.label,
+        displayName: node.displayName,
         tokens: node.tokens,
         model: node.model,
         hasError: node.hasError,
@@ -318,6 +321,7 @@ function calculateReversedLayout(
         branchId: node.branchId,
         timestamp: node.timestamp,
         label: node.label,
+        displayName: node.displayName,
         tokens: node.tokens,
         model: node.model,
         hasError: node.hasError,
@@ -763,9 +767,16 @@ export function renderGraphSVG(layout: GraphLayout, interactive: boolean = true)
         svg += `    <text x="${x + 32}" y="${y + node.height / 2 + 3}" text-anchor="middle" class="graph-node-label" style="font-size: 12px;" title="${title}">${icon}</text>\n`
       }
 
-      // Add request ID (first 8 chars) shifted more to the left
-      const requestIdShort = node.id.substring(0, 8)
-      svg += `    <text x="${x + 42}" y="${y + node.height / 2 + 3}" text-anchor="start" class="graph-node-label" style="font-weight: 500; font-size: 11px;">${requestIdShort}</text>\n`
+      // Add display name (subagent type) or request ID (first 8 chars) shifted more to the left
+      const rawDisplayText = node.displayName || node.id.substring(0, 8)
+      // Truncate if too long and escape HTML for security
+      const displayText =
+        rawDisplayText.length > 20
+          ? escapeHtml(rawDisplayText.substring(0, 17) + '...')
+          : escapeHtml(rawDisplayText)
+      const fullText = escapeHtml(rawDisplayText) // Full text for tooltip
+
+      svg += `    <text x="${x + 42}" y="${y + node.height / 2 + 3}" text-anchor="start" class="graph-node-label" style="font-weight: 500; font-size: 11px;" title="${fullText}">${displayText}</text>\n`
 
       // Add timestamp aligned more to the right
       const time = node.timestamp.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })


### PR DESCRIPTION
## Summary
- Shows sub-agent names (e.g., 'project-documenter', 'thinkdeep') instead of request hash IDs in the conversation tree view
- Improves readability and user experience when viewing conversation flows
- Adds proper security measures with HTML escaping and length truncation

## Changes
- Extract `subagent_type` from `task_tool_invocation` for display
- Add `displayName` property to ConversationNode and LayoutNode interfaces
- Implement XSS-safe rendering with HTML escaping
- Add truncation for long names with tooltip for full text
- Improve task invocation handling to find first valid subagent_type
- Add proper TypeScript types for TaskToolInvocation

## Test Plan
- [x] TypeScript compilation passes
- [x] Security review completed (HTML escaping implemented)
- [ ] Manual testing in dashboard with various conversation types
- [ ] Verify fallback to request hash for non-Task messages

🤖 Generated with [Claude Code](https://claude.ai/code)