### PR TITLE
Fix credential repository integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,22 @@ OAUTH_PROXY_COOKIE_SECRET=
 # Directory for domain credential files (default: ./credentials)
 CREDENTIALS_DIR=./credentials
 
+# ===================
+# Credential Management (ADR-026)
+# ===================
+
+# Enable database-backed credential storage (default: false)
+# false = Use filesystem credentials (safe default)
+# true = Use PostgreSQL database for credentials
+USE_DATABASE_CREDENTIALS=false
+
+# Encryption key for database credentials (AES-256-GCM)
+# Required when USE_DATABASE_CREDENTIALS=true
+# Generate with: openssl rand -base64 48
+# ⚠️ CRITICAL: Store securely! Never commit to version control!
+# Recommended: Use AWS Secrets Manager, HashiCorp Vault, or similar
+# CREDENTIAL_ENCRYPTION_KEY=your-secure-random-48-character-key-here
+
 # Wildcard credential support (default: false)
 # true = Enable wildcard matching, false = Disable, shadow = Log only (no behavior change)
 # When enabled, _wildcard.example.com.credentials.json matches all subdomains of example.com

--- a/docs/04-Architecture/ADRs/adr-026-database-credential-management.md
+++ b/docs/04-Architecture/ADRs/adr-026-database-credential-management.md
@@ -1,0 +1,186 @@
+# ADR-026: Database-Backed Credential Management
+
+## Status
+
+Accepted
+
+## Context
+
+Currently, the proxy stores account credentials and train configurations as JSON files in the filesystem under `credentials/accounts/` and `credentials/train-client-keys/` directories. While this approach is simple and works for single-instance deployments, it has several limitations:
+
+1. **Scalability**: Filesystem-based storage doesn't scale well across multiple instances
+2. **Management**: No centralized interface for managing credentials (requires manual file editing)
+3. **Audit Trail**: Limited ability to track credential access and modifications
+4. **Security**: Credentials stored in plaintext on disk (relying only on filesystem permissions)
+5. **Multi-tenancy**: Difficult to implement fine-grained access control per train
+6. **Discovery**: No easy way to list and search available accounts and trains
+
+The Slack configuration is currently associated with account credentials but logically belongs at the train level, as notifications are train-specific, not account-specific.
+
+## Decision Drivers
+
+- **Dashboard Management**: Need UI to manage accounts and trains without filesystem access
+- **Security**: Encrypt sensitive credentials at rest
+- **Scalability**: Support future multi-instance deployments
+- **Backward Compatibility**: Must not disrupt existing deployments
+- **Auditability**: Track credential usage and modifications
+- **Zero Downtime**: Migration must not require service interruption
+
+## Considered Options
+
+### 1. Big Bang Migration (All at Once)
+
+- Description: Immediate complete migration to database storage
+- Pros: Clean cutover, simpler code
+- Cons: Risky, no rollback, requires downtime, harder to test
+
+### 2. Hybrid Dual-Write
+
+- Description: Write to both filesystem and database simultaneously
+- Pros: Maximum safety during transition
+- Cons: Complex synchronization, eventual consistency issues, data drift risk
+
+### 3. Phased Migration with Feature Flag (SELECTED)
+
+- Description: Gradual migration with filesystem fallback controlled by feature flag
+- Pros: Easy rollback, testable in production, zero downtime, low risk
+- Cons: More code initially (dual paths), requires feature flag management
+
+## Decision
+
+Implement database-backed credential storage using PostgreSQL with a **phased migration approach** controlled by the `USE_DATABASE_CREDENTIALS` feature flag.
+
+### Implementation Details
+
+**Database Schema:**
+
+```sql
+-- Account credentials table
+CREATE TABLE accounts (
+  account_id VARCHAR(255) PRIMARY KEY,
+  account_name VARCHAR(255) UNIQUE NOT NULL,
+  credential_type VARCHAR(20) NOT NULL,  -- 'api_key' or 'oauth'
+  api_key_encrypted TEXT,
+  oauth_access_token_encrypted TEXT,
+  oauth_refresh_token_encrypted TEXT,
+  oauth_expires_at BIGINT,
+  oauth_scopes TEXT[],
+  oauth_is_max BOOLEAN DEFAULT false,
+  is_active BOOLEAN DEFAULT true,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW(),
+  last_used_at TIMESTAMPTZ
+);
+
+-- Train configurations table
+CREATE TABLE trains (
+  train_id VARCHAR(255) PRIMARY KEY,
+  train_name VARCHAR(255),
+  description TEXT,
+  client_api_keys_hashed TEXT[],  -- SHA-256 hashed for security
+  slack_config JSONB,              -- Moved from accounts
+  default_account_id VARCHAR(255) REFERENCES accounts(account_id),
+  is_active BOOLEAN DEFAULT true,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Train-account mappings (many-to-many)
+CREATE TABLE train_account_mappings (
+  train_id VARCHAR(255) REFERENCES trains(train_id) ON DELETE CASCADE,
+  account_id VARCHAR(255) REFERENCES accounts(account_id) ON DELETE CASCADE,
+  priority INTEGER DEFAULT 0,  -- For deterministic selection
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  PRIMARY KEY (train_id, account_id)
+);
+```
+
+**Encryption Strategy:**
+
+- Algorithm: AES-256-GCM (authenticated encryption)
+- Key Derivation: PBKDF2 with 100,000 iterations
+- Storage Format: `salt:iv:authTag:ciphertext` (base64-encoded)
+- Key Source: `CREDENTIAL_ENCRYPTION_KEY` environment variable
+
+**Feature Flag:**
+
+- `USE_DATABASE_CREDENTIALS=false` (default) - Use filesystem
+- `USE_DATABASE_CREDENTIALS=true` - Use database
+
+**Migration Scripts:**
+
+- `013-accounts-trains-schema.ts` - Create tables and indexes
+- `014-import-credentials-data.ts` - Import filesystem data to database
+
+**Dashboard Routes (Future):**
+
+- `/dashboard/accounts` - Account management
+- `/dashboard/trains` - Train configuration and account mapping
+
+## Consequences
+
+### Positive
+
+- **Centralized Management**: Dashboard UI for account and train administration
+- **Enhanced Security**: Credentials encrypted at rest with AES-256-GCM
+- **Better Scalability**: Database storage supports multi-instance deployments
+- **Audit Trail**: Track credential creation, modification, and usage
+- **Improved Organization**: Slack config properly associated with trains
+- **Zero Downtime**: Feature flag enables gradual rollout with rollback capability
+- **Type Safety**: Shared TypeScript types ensure consistency
+
+### Negative
+
+- **Increased Complexity**: Additional database tables and migration scripts
+- **Performance Overhead**: Encryption/decryption on every credential access (mitigated by caching)
+- **Key Management**: Must securely manage `CREDENTIAL_ENCRYPTION_KEY`
+- **Migration Required**: Existing deployments must run migration scripts
+
+### Risks and Mitigations
+
+- **Risk**: Encryption key exposure or loss
+  - **Mitigation**: Document key management best practices, recommend secrets management tools
+
+- **Risk**: Database performance impact on credential lookups
+  - **Mitigation**: Indexes on frequently queried columns, existing credential caching layer
+
+- **Risk**: Data migration failures
+  - **Mitigation**: Idempotent migration scripts, keep filesystem as backup during transition
+
+- **Risk**: Feature flag misconfiguration
+  - **Mitigation**: Safe default (filesystem), clear documentation, validation checks
+
+## Links
+
+- [ADR-004: Proxy Authentication](./adr-004-proxy-authentication.md) - Account selection logic
+- [ADR-012: Database Schema Evolution](./adr-012-database-schema-evolution.md) - Migration patterns
+- [ADR-024: Train-ID Header Routing](./adr-024-train-id-header-routing.md) - Train identification
+- [Environment Variables Reference](../../06-Reference/environment-vars.md)
+
+## Notes
+
+**Migration Path:**
+
+1. Phase 1: Create schema (migration 013)
+2. Phase 2: Import existing data (migration 014)
+3. Phase 3: Deploy with `USE_DATABASE_CREDENTIALS=false` (filesystem fallback)
+4. Phase 4: Enable database mode per train/instance
+5. Phase 5: Remove filesystem fallback after full validation
+
+**Key Management Recommendations:**
+
+- Use AWS Secrets Manager, HashiCorp Vault, or similar for production
+- Rotate encryption keys periodically (requires re-encryption migration)
+- Never commit `CREDENTIAL_ENCRYPTION_KEY` to version control
+
+**Future Enhancements:**
+
+- Row-level security for multi-tenant isolation
+- Credential rotation workflow via dashboard
+- Integration with external secret managers
+- OAuth token refresh using database locks for multi-instance support
+
+---
+
+Date: 2025-10-04
+Authors: Claude Code (AI Agent)

--- a/docs/04-Architecture/train-credential-migration-roadmap.md
+++ b/docs/04-Architecture/train-credential-migration-roadmap.md
@@ -1,0 +1,1393 @@
+# Train-ID and Credential Management Migration Roadmap
+
+## Executive Summary
+
+This document outlines the implementation roadmap for migrating train-id and credential management from filesystem-based storage to PostgreSQL database. This migration enables centralized management through a dashboard interface while maintaining backward compatibility.
+
+**Current Status:** Phase 2 Complete (Repository Layer)
+**Phase 1 PR:** [#144](https://github.com/Moonsong-Labs/agent-prompttrain/pull/144) - Foundation (Merged)
+**Phase 2 Commits:** ac42415, 331ad9b - Repository Layer (In Progress)
+**ADR:** [ADR-026: Database Credential Management](./ADRs/adr-026-database-credential-management.md)
+
+---
+
+## Phase 1: Foundation (COMPLETED ✅)
+
+### What Was Implemented
+
+#### 1. Database Schema (Migration 013)
+
+**Location:** `scripts/db/migrations/013-accounts-trains-schema.ts`
+
+Created three core tables with comprehensive constraints and indexes:
+
+**accounts table:**
+
+- Stores Anthropic account credentials (API keys and OAuth tokens)
+- Encrypted storage for sensitive data using AES-256-GCM
+- Supports both `api_key` and `oauth` credential types
+- Includes audit fields: `created_at`, `updated_at`, `last_used_at`
+- Soft delete support via `is_active` flag
+- Constraint ensures proper credentials based on type
+
+**trains table:**
+
+- Stores train configurations and metadata
+- Contains hashed client API keys (SHA-256) for security
+- Includes Slack configuration (moved from accounts table)
+- References default account via foreign key
+- Supports soft delete and audit tracking
+
+**train_account_mappings table:**
+
+- Many-to-many relationship between trains and accounts
+- Priority field for deterministic account selection
+- Cascade delete when train or account is removed
+
+**Indexes Created:**
+
+- `idx_accounts_type` - Fast lookup by credential type
+- `idx_accounts_active` - Partial index on active accounts
+- `idx_accounts_last_used` - Track usage patterns
+- `idx_trains_active` - Partial index on active trains
+- `idx_trains_default_account` - Fast lookup by default account
+- `idx_train_mappings_train` - Efficient mapping queries
+- `idx_train_mappings_account` - Reverse mapping lookup
+- `idx_train_mappings_priority` - Priority-based selection
+
+#### 2. Data Import Script (Migration 014)
+
+**Location:** `scripts/db/migrations/014-import-credentials-data.ts`
+
+Implements idempotent data migration from filesystem to database:
+
+**Features:**
+
+- Reads existing credential files from `credentials/accounts/`
+- Reads train client keys from `credentials/train-client-keys/`
+- Encrypts sensitive fields before database insertion
+- Uses `ON CONFLICT` for idempotent re-runs
+- Validates encryption key presence and length
+- Provides detailed import summary and verification
+- Gracefully handles missing directories
+- Transaction-based with rollback on errors
+
+**Security Measures:**
+
+- Requires `CREDENTIAL_ENCRYPTION_KEY` (minimum 32 characters)
+- Encrypts: API keys, OAuth access tokens, OAuth refresh tokens
+- Hashes: Client API keys (one-way SHA-256)
+- Validates data integrity after import
+
+#### 3. TypeScript Type Definitions
+
+**Location:** `packages/shared/src/types/credentials.ts`
+
+Created comprehensive type definitions:
+
+```typescript
+// Database representation (encrypted)
+interface DatabaseAccount {
+  accountId: string
+  accountName: string
+  credentialType: 'api_key' | 'oauth'
+  apiKeyEncrypted?: string
+  oauthAccessTokenEncrypted?: string
+  oauthRefreshTokenEncrypted?: string
+  oauthExpiresAt?: number
+  oauthScopes?: string[]
+  oauthIsMax?: boolean
+  isActive: boolean
+  createdAt: Date
+  updatedAt: Date
+  lastUsedAt?: Date
+}
+
+interface DatabaseTrain {
+  trainId: string
+  trainName?: string
+  description?: string
+  clientApiKeysHashed?: string[]
+  slackConfig?: Record<string, unknown>
+  defaultAccountId?: string
+  isActive: boolean
+  createdAt: Date
+  updatedAt: Date
+}
+
+interface TrainAccountMapping {
+  trainId: string
+  accountId: string
+  priority: number
+  createdAt: Date
+}
+
+// Application representation (decrypted)
+interface DecryptedAccount {
+  accountId: string
+  accountName: string
+  credentialType: 'api_key' | 'oauth'
+  apiKey?: string
+  oauthAccessToken?: string
+  oauthRefreshToken?: string
+  oauthExpiresAt?: number
+  oauthScopes?: string[]
+  oauthIsMax?: boolean
+  isActive: boolean
+  lastUsedAt?: Date
+}
+```
+
+#### 4. Encryption Utilities
+
+**Location:** `packages/shared/src/utils/encryption.ts`
+
+Implemented secure encryption functions:
+
+**Algorithm:** AES-256-GCM (Galois/Counter Mode)
+
+- Provides both confidentiality and authenticity
+- 256-bit key strength
+- 128-bit authentication tag prevents tampering
+
+**Key Derivation:** PBKDF2
+
+- 100,000 iterations (OWASP recommended minimum)
+- SHA-256 hash function
+- 32-byte salt (randomly generated per encryption)
+- Derives 32-byte encryption key from master key
+
+**Storage Format:** `salt:iv:authTag:ciphertext` (all base64-encoded)
+
+- Salt: 32 bytes (for key derivation)
+- IV: 16 bytes (initialization vector)
+- Auth Tag: 16 bytes (GCM authentication tag)
+- Ciphertext: Variable length (encrypted data)
+
+**Functions Provided:**
+
+- `encrypt(plaintext, key)` - Encrypt sensitive data
+- `decrypt(ciphertext, key)` - Decrypt stored data
+- `hashApiKey(apiKey)` - One-way hash for client keys
+- `verifyApiKeyHash(apiKey, hash)` - Constant-time verification
+
+#### 5. Configuration Updates
+
+**Location:** `packages/shared/src/config/index.ts`
+
+Added new configuration section:
+
+```typescript
+credentials: {
+  get useDatabaseStorage() {
+    return env.bool('USE_DATABASE_CREDENTIALS', false)
+  },
+  get encryptionKey() {
+    return env.string('CREDENTIAL_ENCRYPTION_KEY', '')
+  },
+}
+```
+
+**Environment Variables:**
+
+- `USE_DATABASE_CREDENTIALS` - Feature flag (default: false)
+- `CREDENTIAL_ENCRYPTION_KEY` - Encryption key (required when enabled)
+
+#### 6. Documentation
+
+**ADR-026:** Complete architectural decision record
+
+- Context and problem statement
+- Decision drivers and options considered
+- Implementation details and schema design
+- Consequences (positive, negative, risks)
+- Migration path and rollout strategy
+
+**Environment Variables Reference:**
+
+- Updated with credential management section
+- Security notes and best practices
+- Key generation instructions
+- Production recommendations (AWS Secrets Manager, etc.)
+
+**Example Configuration:**
+
+- Updated `.env.example` with new variables
+- Clear comments and security warnings
+- Key generation command examples
+
+### Key Architectural Decisions
+
+1. **Slack Config Location:** Moved from accounts to trains table
+   - Rationale: Notifications are train-specific, not account-specific
+   - Allows different Slack configurations per train
+   - More logical data organization
+
+2. **Application-Level Encryption:** Not pgcrypto
+   - Better control over encryption logic
+   - Easier key rotation strategy
+   - No database extension dependencies
+   - Portable across PostgreSQL versions
+
+3. **Feature Flag Approach:** Gradual rollout
+   - Safe default: filesystem mode (USE_DATABASE_CREDENTIALS=false)
+   - Easy rollback without code changes
+   - Test in production with subset of trains
+   - No breaking changes to existing deployments
+
+4. **Idempotent Migrations:** Can be run multiple times
+   - Uses `IF NOT EXISTS` for tables and indexes
+   - Uses `ON CONFLICT` for data insertion
+   - Transaction-based with rollback
+   - Verification steps after each operation
+
+### Code Review Results
+
+**Overall Status:** APPROVED ✅
+
+**Strengths Identified:**
+
+- Excellent encryption implementation (AES-256-GCM + PBKDF2)
+- Proper database design with constraints and indexes
+- Idempotent migrations following ADR-012 patterns
+- Comprehensive TypeScript types
+- Feature flag for safe rollout
+- Thorough documentation
+- Transaction-based error handling
+
+**Minor Recommendations (Non-Blocking):**
+
+1. Consider using `crypto.timingSafeEqual()` in `verifyApiKeyHash` to prevent timing attacks
+2. Add JSON structure validation in migration 014 after parsing
+3. Add explicit comment about automatic index on `account_name` UNIQUE constraint
+
+**Security Assessment:** Strong
+**Code Quality:** High
+**Documentation:** Excellent
+
+---
+
+## Phase 2: Repository Layer (COMPLETED ✅)
+
+### What Was Implemented
+
+Implemented the repository pattern with dual implementations (database and filesystem) controlled by feature flag. This provides an abstraction layer for credential access while maintaining 100% backward compatibility.
+
+**Commits:** ac42415 (implementations), 331ad9b (integration)
+
+#### Repository Interfaces
+
+**Location:** `services/proxy/src/repositories/IAccountRepository.ts`
+
+Defines the contract for account credential operations:
+
+- `listAccountNames()` - Returns all available account names
+- `getAccountByName()` - Fetches a decrypted account
+- `getApiKey()` - Gets API key or OAuth access token (with auto-refresh check)
+- `updateOAuthTokens()` - Updates OAuth credentials (concurrency-safe)
+- `updateLastUsed()` - Tracks account usage
+- `clearCache()` - Clears credential cache
+
+**Location:** `services/proxy/src/repositories/ITrainRepository.ts`
+
+Defines the contract for train-specific operations:
+
+- `getAccountNamesForTrain()` - Returns mapped account names for a train (priority-ordered)
+- `getAccountsForTrain()` - Returns full decrypted accounts for a train
+- `validateClientKey()` - Validates hashed client API keys
+- `getSlackConfig()` - Retrieves train-specific Slack configuration
+
+#### Repository Implementations
+
+**Filesystem Repositories:**
+
+**Location:** `services/proxy/src/repositories/FilesystemAccountRepository.ts`
+
+```typescript
+import { Pool } from 'pg'
+import { DecryptedAccount } from '@agent-prompttrain/shared'
+
+export interface IAccountRepository {
+  // Core operations
+  getAccount(accountId: string): Promise<DecryptedAccount | null>
+  listAccounts(): Promise<DecryptedAccount[]>
+  updateOAuthTokens(accountId: string, tokens: OAuthTokens): Promise<void>
+  updateLastUsed(accountId: string): Promise<void>
+
+  // OAuth-specific
+  getAccountForRefresh(accountId: string): Promise<DecryptedAccount | null>
+}
+
+// Database implementation
+export class DatabaseAccountRepository implements IAccountRepository {
+  constructor(
+    private pool: Pool,
+    private encryptionKey: string
+  ) {}
+
+  async getAccount(accountId: string): Promise<DecryptedAccount | null> {
+    // SELECT from accounts table
+    // Decrypt credentials using encryption utilities
+    // Return DecryptedAccount
+  }
+
+  async getAccountForRefresh(accountId: string): Promise<DecryptedAccount | null> {
+    // Use SELECT ... FOR UPDATE to lock row during OAuth refresh
+    // Prevents concurrent refresh attempts
+    // Returns locked account for safe token update
+  }
+
+  async updateOAuthTokens(accountId: string, tokens: OAuthTokens): Promise<void> {
+    // Encrypt new tokens
+    // UPDATE accounts SET oauth_access_token_encrypted = $1, ...
+    // Update expires_at and updated_at
+  }
+
+  async listAccounts(): Promise<DecryptedAccount[]> {
+    // SELECT all active accounts
+    // Decrypt each account's credentials
+    // Return array of DecryptedAccount
+  }
+}
+
+// Filesystem implementation (existing logic)
+export class FilesystemAccountRepository implements IAccountRepository {
+  // Wrap existing file-based logic from credentials.ts
+  // Maintain current behavior for backward compatibility
+}
+```
+
+#### 2. Train Repository Interface
+
+**Location:** `services/proxy/src/repositories/TrainRepository.ts`
+
+```typescript
+export interface ITrainRepository {
+  getTrain(trainId: string): Promise<Train | null>
+  getTrainAccounts(trainId: string): Promise<string[]>
+  validateClientKey(trainId: string, clientKey: string): Promise<boolean>
+  getSlackConfig(trainId: string): Promise<SlackConfig | null>
+}
+
+export class DatabaseTrainRepository implements ITrainRepository {
+  async validateClientKey(trainId: string, clientKey: string): Promise<boolean> {
+    // Hash the provided key
+    // Check if hash exists in client_api_keys_hashed array
+    // Use ANY() operator for array membership check
+  }
+
+  async getTrainAccounts(trainId: string): Promise<string[]> {
+    // Query train_account_mappings
+    // Join with accounts table
+    // Return ordered by priority
+  }
+
+  async getSlackConfig(trainId: string): Promise<SlackConfig | null> {
+    // SELECT slack_config FROM trains WHERE train_id = $1
+    // Parse JSONB to SlackConfig type
+  }
+}
+
+export class FilesystemTrainRepository implements ITrainRepository {
+  // Wrap existing train client key file logic
+  // No Slack config in filesystem (will be null)
+}
+```
+
+#### 3. Repository Factory
+
+**Location:** `services/proxy/src/repositories/index.ts`
+
+```typescript
+import { config } from '@agent-prompttrain/shared'
+import { Pool } from 'pg'
+
+export function createRepositories(pool: Pool): {
+  accountRepo: IAccountRepository
+  trainRepo: ITrainRepository
+} {
+  if (config.credentials.useDatabaseStorage) {
+    // Validate encryption key
+    if (!config.credentials.encryptionKey || config.credentials.encryptionKey.length < 32) {
+      throw new Error('CREDENTIAL_ENCRYPTION_KEY must be set and at least 32 characters')
+    }
+
+    return {
+      accountRepo: new DatabaseAccountRepository(pool, config.credentials.encryptionKey),
+      trainRepo: new DatabaseTrainRepository(pool),
+    }
+  }
+
+  return {
+    accountRepo: new FilesystemAccountRepository(),
+    trainRepo: new FilesystemTrainRepository(),
+  }
+}
+```
+
+#### 4. Update Authentication Service
+
+**Location:** `services/proxy/src/services/AuthenticationService.ts`
+
+Modify to use repository pattern instead of direct file access:
+
+```typescript
+export class AuthenticationService {
+  constructor(
+    private accountRepo: IAccountRepository,
+    private trainRepo: ITrainRepository
+  ) {}
+
+  async authenticate(context: RequestContext): Promise<AuthResult> {
+    // Use accountRepo.listAccounts() instead of file listing
+    // Use accountRepo.getAccount() instead of file reading
+    // Maintain existing deterministic selection logic
+  }
+
+  async getClientApiKeys(trainId: string): Promise<string[]> {
+    // Use trainRepo.validateClientKey() instead of file reading
+  }
+}
+```
+
+#### 5. Update OAuth Refresh Logic
+
+**Location:** `services/proxy/src/credentials.ts`
+
+Modify `getApiKey` function to use repository:
+
+```typescript
+export async function getApiKey(
+  credentialPath: string,
+  accountRepo: IAccountRepository
+): Promise<string | null> {
+  // Extract accountId from credentialPath
+  // Use accountRepo.getAccount() instead of loadCredentials()
+
+  // For OAuth, check if refresh needed
+  if (needsRefresh) {
+    // Use accountRepo.getAccountForRefresh() to lock row
+    // Perform token refresh
+    // Use accountRepo.updateOAuthTokens() to save
+  }
+
+  return accessToken
+}
+```
+
+### Implementation Checklist
+
+- [ ] Create `IAccountRepository` interface
+- [ ] Implement `DatabaseAccountRepository` with encryption
+- [ ] Implement `FilesystemAccountRepository` (wrap existing)
+- [ ] Create `ITrainRepository` interface
+- [ ] Implement `DatabaseTrainRepository`
+- [ ] Implement `FilesystemTrainRepository`
+- [ ] Create repository factory with feature flag logic
+- [ ] Update `AuthenticationService` to use repositories
+- [ ] Update OAuth refresh to use database locks
+- [ ] Add unit tests for repository implementations
+- [ ] Add integration tests for feature flag switching
+
+### Testing Strategy
+
+**Unit Tests:**
+
+```typescript
+describe('DatabaseAccountRepository', () => {
+  it('should decrypt credentials correctly', async () => {
+    // Test encryption/decryption round-trip
+  })
+
+  it('should lock account during OAuth refresh', async () => {
+    // Test SELECT FOR UPDATE behavior
+  })
+
+  it('should handle concurrent refresh attempts', async () => {
+    // Test that only one refresh happens
+  })
+})
+
+describe('DatabaseTrainRepository', () => {
+  it('should validate client API keys correctly', async () => {
+    // Test hash verification
+  })
+
+  it('should return accounts in priority order', async () => {
+    // Test train_account_mappings query
+  })
+})
+```
+
+**Integration Tests:**
+
+```typescript
+describe('Feature Flag Switching', () => {
+  it('should use filesystem when flag is false', async () => {
+    process.env.USE_DATABASE_CREDENTIALS = 'false'
+    // Verify filesystem repositories are used
+  })
+
+  it('should use database when flag is true', async () => {
+    process.env.USE_DATABASE_CREDENTIALS = 'true'
+    // Verify database repositories are used
+  })
+})
+```
+
+---
+
+## Phase 3: Dashboard Management UI (FUTURE)
+
+### Overview
+
+Create HTMX-based dashboard routes for managing accounts and trains. Follows existing dashboard architecture (ADR-009) with server-side rendering and progressive enhancement.
+
+### Routes to Implement
+
+#### 1. Account Management
+
+**Location:** `services/dashboard/src/routes/accounts.ts`
+
+```typescript
+// List all accounts
+GET /dashboard/accounts
+  - Display table of all accounts
+  - Show: account name, type, status, last used
+  - Filter by type (API key / OAuth)
+  - Search by account name
+  - Click row to view details
+
+// View account details
+GET /dashboard/accounts/:id
+  - Show full account information
+  - Display credential type and metadata
+  - Show OAuth expiry if applicable
+  - List associated trains
+  - Edit/delete buttons
+
+// Create account form
+GET /dashboard/accounts/new
+POST /dashboard/accounts
+  - HTMX form with real-time validation
+  - Account name (required, unique)
+  - Credential type selector (API key / OAuth)
+  - Conditional fields based on type
+  - Encrypt credentials before saving
+
+// Update account
+GET /dashboard/accounts/:id/edit
+PUT /dashboard/accounts/:id
+  - Pre-filled form with existing data
+  - Allow credential rotation
+  - Re-encrypt on save
+  - HTMX partial update
+
+// Delete account (soft delete)
+DELETE /dashboard/accounts/:id
+  - Confirm modal via HTMX
+  - Set is_active = false
+  - Remove from train mappings (or warn if in use)
+```
+
+#### 2. Train Management
+
+**Location:** `services/dashboard/src/routes/trains.ts`
+
+```typescript
+// List all trains
+GET /dashboard/trains
+  - Display table of all trains
+  - Show: train ID, name, account count, status
+  - Filter by active/inactive
+  - Search by train ID/name
+  - Click row to view details
+
+// View train details
+GET /dashboard/trains/:id
+  - Show train information
+  - Display client API keys (hashed)
+  - Show Slack configuration
+  - List mapped accounts with priorities
+  - Edit/delete buttons
+
+// Create train
+GET /dashboard/trains/new
+POST /dashboard/trains
+  - Train ID (required, unique)
+  - Train name (optional)
+  - Description (optional)
+  - Client API keys (multiline input)
+  - Slack configuration (JSON editor or form)
+  - Hash keys before saving
+
+// Update train
+GET /dashboard/trains/:id/edit
+PUT /dashboard/trains/:id
+  - Pre-filled form
+  - Allow key rotation
+  - Update Slack config
+  - HTMX partial update
+
+// Manage account mappings
+GET /dashboard/trains/:id/accounts
+POST /dashboard/trains/:id/accounts
+DELETE /dashboard/trains/:id/accounts/:accountId
+  - Drag-and-drop priority ordering
+  - Add/remove account mappings
+  - Set default account
+  - Real-time updates via HTMX
+```
+
+#### 3. HTMX Patterns
+
+**List View with Filters:**
+
+```html
+<form hx-get="/dashboard/accounts" hx-target="#accounts-table">
+  <input
+    type="search"
+    name="q"
+    placeholder="Search accounts..."
+    hx-trigger="keyup changed delay:300ms"
+  />
+  <select name="type" hx-trigger="change">
+    <option value="">All Types</option>
+    <option value="api_key">API Key</option>
+    <option value="oauth">OAuth</option>
+  </select>
+</form>
+
+<div id="accounts-table">
+  <!-- Server-rendered table with HTMX attributes -->
+</div>
+```
+
+**Create Form with Validation:**
+
+```html
+<form hx-post="/dashboard/accounts" hx-target="#form-container">
+  <input
+    name="account_name"
+    hx-post="/dashboard/accounts/validate"
+    hx-trigger="blur"
+    hx-target="#name-validation"
+  />
+  <div id="name-validation"></div>
+
+  <select name="credential_type" hx-get="/dashboard/accounts/fields" hx-target="#credential-fields">
+    <option value="api_key">API Key</option>
+    <option value="oauth">OAuth</option>
+  </select>
+
+  <div id="credential-fields">
+    <!-- Dynamic fields based on type -->
+  </div>
+
+  <button type="submit">Create Account</button>
+</form>
+```
+
+**Account-Train Mapping Interface:**
+
+```html
+<div id="account-mappings">
+  <div class="mapping-list" hx-swap="outerHTML">
+    <!-- Draggable account items with priority -->
+    <div class="account-item" data-priority="0" draggable="true">
+      <span class="drag-handle">⋮⋮</span>
+      <span class="account-name">account-1</span>
+      <button hx-delete="/dashboard/trains/{id}/accounts/account-1">Remove</button>
+    </div>
+  </div>
+
+  <form hx-post="/dashboard/trains/{id}/accounts">
+    <select name="account_id">
+      <!-- Available accounts -->
+    </select>
+    <button type="submit">Add Account</button>
+  </form>
+</div>
+```
+
+### UI Components to Build
+
+**1. Account Card Component**
+
+- Display account info in card format
+- Show credential type badge
+- OAuth expiry indicator
+- Last used timestamp
+- Quick actions (edit, delete)
+
+**2. Train Card Component**
+
+- Train ID and name
+- Account count badge
+- Slack config indicator
+- Client key count
+- Status badge (active/inactive)
+
+**3. Credential Form Components**
+
+- API key input with show/hide toggle
+- OAuth token fields (access, refresh)
+- Scope selector (checkboxes)
+- Max tier toggle
+- Validation indicators
+
+**4. Slack Config Editor**
+
+- Webhook URL input
+- Channel selector
+- Username and emoji inputs
+- Test button (send test message)
+- Enable/disable toggle
+
+**5. Priority Ordering UI**
+
+- Drag-and-drop interface
+- Visual priority indicators
+- Save order button
+- Reset to default
+
+### Security Considerations
+
+**1. Dashboard Authentication**
+
+- Enforce `DASHBOARD_API_KEY` in production (ADR-019)
+- Session-based authentication
+- CSRF protection on forms
+- Rate limiting on endpoints
+
+**2. Credential Display**
+
+- Never show plaintext credentials
+- Masked display with "show" toggle
+- Audit log for credential views
+- Time-limited display (auto-hide after 30s)
+
+**3. Input Validation**
+
+- Sanitize all user inputs
+- Validate credential formats
+- Check for injection attempts
+- Server-side validation (never trust client)
+
+**4. Audit Trail**
+
+- Log all create/update/delete operations
+- Track who made changes (if user auth implemented)
+- Timestamp all modifications
+- Immutable audit log
+
+### Implementation Checklist
+
+- [ ] Create account list route with filters
+- [ ] Create account detail route
+- [ ] Create account create/edit forms
+- [ ] Create account delete confirmation
+- [ ] Create train list route with filters
+- [ ] Create train detail route
+- [ ] Create train create/edit forms
+- [ ] Create train-account mapping interface
+- [ ] Build HTMX partial templates
+- [ ] Implement drag-and-drop priority ordering
+- [ ] Add Slack config editor
+- [ ] Implement credential masking/unmasking
+- [ ] Add form validation (client and server)
+- [ ] Create audit logging for all operations
+- [ ] Add E2E tests for CRUD operations
+- [ ] Update navigation to include new routes
+
+---
+
+## Phase 4: Integration Testing (FUTURE)
+
+### Test Categories
+
+#### 1. Migration Tests
+
+**Location:** `scripts/db/migrations/__tests__/`
+
+```typescript
+describe('Migration 013: Schema Creation', () => {
+  it('should create all tables', async () => {
+    // Run migration
+    // Verify tables exist
+    // Check constraints and indexes
+  })
+
+  it('should be idempotent', async () => {
+    // Run migration twice
+    // Verify no errors
+    // Check data integrity
+  })
+})
+
+describe('Migration 014: Data Import', () => {
+  it('should import all filesystem credentials', async () => {
+    // Create test credential files
+    // Run migration
+    // Verify data in database
+    // Check encryption
+  })
+
+  it('should handle missing directories gracefully', async () => {
+    // Run without credential files
+    // Verify no errors
+    // Check empty tables
+  })
+})
+```
+
+#### 2. Repository Tests
+
+**Location:** `services/proxy/src/repositories/__tests__/`
+
+```typescript
+describe('DatabaseAccountRepository', () => {
+  it('should retrieve and decrypt account correctly', async () => {
+    // Insert encrypted account
+    // Retrieve via repository
+    // Verify decrypted values
+  })
+
+  it('should update OAuth tokens atomically', async () => {
+    // Simulate concurrent refresh
+    // Verify only one succeeds
+    // Check final state
+  })
+})
+```
+
+#### 3. End-to-End Tests
+
+**Location:** `e2e/credential-management.spec.ts`
+
+```typescript
+describe('Credential Management E2E', () => {
+  test('should create account via dashboard', async ({ page }) => {
+    await page.goto('/dashboard/accounts/new')
+    await page.fill('[data-testid="account-name"]', 'test-account')
+    await page.selectOption('[data-testid="credential-type"]', 'api_key')
+    await page.fill('[data-testid="api-key"]', 'test-key-123')
+    await page.click('[data-testid="submit"]')
+
+    // Verify account created
+    await expect(page.locator('[data-testid="account-list"]')).toContainText('test-account')
+  })
+
+  test('should authenticate using database credentials', async () => {
+    // Enable database mode
+    // Make proxy request
+    // Verify authentication works
+    // Check last_used_at updated
+  })
+})
+```
+
+#### 4. Performance Tests
+
+**Location:** `services/proxy/src/__tests__/performance/`
+
+```typescript
+describe('Credential Lookup Performance', () => {
+  it('should retrieve credentials under 100ms p99', async () => {
+    // Benchmark database lookup
+    // Compare with filesystem
+    // Verify cache effectiveness
+  })
+
+  it('should handle concurrent OAuth refresh', async () => {
+    // Simulate 100 concurrent requests
+    // Verify only one refresh occurs
+    // Check performance impact
+  })
+})
+```
+
+### Testing Strategy
+
+**1. Unit Tests**
+
+- Test each repository function independently
+- Mock database connections
+- Verify encryption/decryption
+- Test error handling
+
+**2. Integration Tests**
+
+- Test repository with real database
+- Verify feature flag switching
+- Test OAuth refresh flow
+- Check audit logging
+
+**3. E2E Tests**
+
+- Test complete user flows
+- Dashboard CRUD operations
+- Proxy authentication with database credentials
+- Migration process
+
+**4. Performance Tests**
+
+- Benchmark credential lookup times
+- Test concurrent access patterns
+- Measure cache effectiveness
+- Compare filesystem vs database performance
+
+### Test Data Setup
+
+**Test Fixtures:**
+
+```typescript
+// Test accounts
+const testAccounts = [
+  {
+    accountId: 'acc_test_api',
+    accountName: 'test-api-account',
+    credentialType: 'api_key',
+    apiKey: 'sk-ant-test-key-123',
+  },
+  {
+    accountId: 'acc_test_oauth',
+    accountName: 'test-oauth-account',
+    credentialType: 'oauth',
+    oauthAccessToken: 'access-token-123',
+    oauthRefreshToken: 'refresh-token-456',
+    oauthExpiresAt: Date.now() + 3600000,
+  },
+]
+
+// Test trains
+const testTrains = [
+  {
+    trainId: 'test-train-1',
+    trainName: 'Test Train',
+    clientApiKeys: ['cnp_test_key_1', 'cnp_test_key_2'],
+    slackConfig: {
+      webhook_url: 'https://hooks.slack.com/test',
+      channel: '#test-alerts',
+    },
+  },
+]
+```
+
+---
+
+## Phase 5: Production Rollout (FUTURE)
+
+### Pre-Deployment Checklist
+
+**1. Security Validation**
+
+- [ ] Encryption key securely stored (AWS Secrets Manager / Vault)
+- [ ] Key rotation procedure documented
+- [ ] Audit logging enabled and tested
+- [ ] Dashboard authentication verified (DASHBOARD_API_KEY set)
+- [ ] SSL/TLS enabled for database connections
+- [ ] Credential masking working in dashboard
+- [ ] No credentials in application logs
+
+**2. Performance Validation**
+
+- [ ] Credential lookup < 100ms p99
+- [ ] OAuth refresh working with database locks
+- [ ] Cache effectiveness verified
+- [ ] Database indexes optimized
+- [ ] Connection pooling configured
+- [ ] Query performance analyzed
+
+**3. Operational Readiness**
+
+- [ ] Migration scripts tested on staging
+- [ ] Rollback procedure documented
+- [ ] Monitoring dashboards created
+- [ ] Alert thresholds configured
+- [ ] On-call runbook updated
+- [ ] Backup strategy verified
+
+**4. Documentation Complete**
+
+- [ ] ADR-026 finalized
+- [ ] Environment variables documented
+- [ ] Migration guide written
+- [ ] Dashboard user guide created
+- [ ] Troubleshooting guide prepared
+
+### Rollout Strategy
+
+**Stage 1: Staging Validation (Week 1)**
+
+1. Deploy to staging with `USE_DATABASE_CREDENTIALS=false`
+2. Run migration scripts on staging database
+3. Verify data import successful
+4. Run full test suite
+5. Enable database mode (`USE_DATABASE_CREDENTIALS=true`)
+6. Monitor for 48 hours:
+   - Credential lookup latency
+   - OAuth refresh operations
+   - Error rates and logs
+   - Database connection pool utilization
+
+**Stage 2: Production Migration (Week 2)**
+
+1. **Maintenance Window Planning**
+   - Schedule 2-hour window
+   - Notify all stakeholders
+   - Prepare rollback plan
+
+2. **Migration Execution**
+
+   ```bash
+   # Backup current state
+   pg_dump $DATABASE_URL > backup_before_migration.sql
+
+   # Run migrations
+   bun run scripts/db/migrations/013-accounts-trains-schema.ts
+   bun run scripts/db/migrations/014-import-credentials-data.ts
+
+   # Verify data
+   psql $DATABASE_URL -c "SELECT COUNT(*) FROM accounts;"
+   psql $DATABASE_URL -c "SELECT COUNT(*) FROM trains;"
+   ```
+
+3. **Deploy with Feature Flag Off**
+
+   ```bash
+   # Deploy code
+   USE_DATABASE_CREDENTIALS=false
+   CREDENTIAL_ENCRYPTION_KEY=$ENCRYPTION_KEY
+
+   # Restart services
+   docker-compose restart proxy dashboard
+   ```
+
+4. **Validate Deployment**
+   - Check all services healthy
+   - Verify filesystem mode working
+   - Monitor error logs
+   - Test sample requests
+
+**Stage 3: Gradual Enablement (Week 3)**
+
+1. **Enable for 10% of Trains**
+
+   ```sql
+   -- Mark specific trains for database mode
+   UPDATE trains SET use_database = true
+   WHERE train_id IN ('train-1', 'train-2', 'train-3');
+   ```
+
+2. **Monitor for 24 Hours**
+   - Credential lookup latency
+   - OAuth refresh success rate
+   - Error rates compared to baseline
+   - Database query performance
+
+3. **Enable for 50% of Trains**
+   - Continue monitoring
+   - Compare metrics between database and filesystem modes
+
+4. **Enable for 100% of Trains**
+   - Full cutover to database mode
+   - Keep filesystem as backup for 30 days
+
+**Stage 4: Cleanup (Week 4)**
+
+1. **After 30 Days of Stable Operation**
+   - Remove filesystem fallback code
+   - Delete credential files (after backup)
+   - Update documentation to database-only
+   - Remove feature flag
+
+### Monitoring and Alerts
+
+**Key Metrics to Track:**
+
+1. **Performance Metrics**
+   - Credential lookup latency (p50, p95, p99)
+   - OAuth refresh duration
+   - Database query time
+   - Cache hit rate
+
+2. **Error Metrics**
+   - Authentication failures
+   - Decryption errors
+   - Database connection errors
+   - OAuth refresh failures
+
+3. **Usage Metrics**
+   - Accounts accessed per minute
+   - Trains active per hour
+   - Database credentials usage percentage
+   - Filesystem fallback usage (should trend to 0)
+
+**Alert Thresholds:**
+
+```yaml
+alerts:
+  - name: credential_lookup_slow
+    condition: p99_latency > 200ms
+    severity: warning
+
+  - name: decryption_errors
+    condition: error_rate > 1%
+    severity: critical
+
+  - name: database_connection_failure
+    condition: db_errors > 5 in 5m
+    severity: critical
+
+  - name: oauth_refresh_failures
+    condition: refresh_failures > 10%
+    severity: warning
+```
+
+### Rollback Procedures
+
+**Immediate Rollback (< 5 minutes):**
+
+```bash
+# Set feature flag to filesystem mode
+USE_DATABASE_CREDENTIALS=false
+
+# Restart services
+docker-compose restart proxy dashboard
+
+# Verify rollback
+curl http://localhost:3000/health
+```
+
+**Data Rollback (if corruption detected):**
+
+```bash
+# Restore from backup
+psql $DATABASE_URL < backup_before_migration.sql
+
+# Verify restore
+psql $DATABASE_URL -c "SELECT COUNT(*) FROM accounts;"
+
+# Restart services
+docker-compose restart proxy dashboard
+```
+
+**Partial Rollback (specific trains):**
+
+```sql
+-- Disable database mode for problematic trains
+UPDATE trains SET use_database = false
+WHERE train_id IN ('problematic-train-1', 'problematic-train-2');
+```
+
+---
+
+## Success Metrics
+
+### Phase 1 (Foundation) ✅
+
+- [x] Database schema created successfully
+- [x] Migration scripts are idempotent
+- [x] TypeScript types defined
+- [x] Encryption utilities implemented
+- [x] Configuration updated
+- [x] Documentation complete
+- [x] Code review approved
+
+### Phase 2 (Repository Layer)
+
+- [ ] Repository interfaces defined
+- [ ] Database repositories implemented with encryption
+- [ ] Filesystem repositories wrap existing logic
+- [ ] Feature flag switching works correctly
+- [ ] OAuth refresh uses database locks
+- [ ] Unit tests pass (>90% coverage)
+- [ ] Integration tests pass
+
+### Phase 3 (Dashboard UI)
+
+- [ ] All CRUD routes implemented
+- [ ] HTMX patterns working correctly
+- [ ] Credential masking functional
+- [ ] Slack config editor working
+- [ ] Account-train mapping UI complete
+- [ ] E2E tests pass
+- [ ] Security audit passed
+
+### Phase 4 (Testing)
+
+- [ ] Migration tests pass
+- [ ] Repository tests pass
+- [ ] E2E tests pass
+- [ ] Performance benchmarks met (<100ms p99)
+- [ ] Load testing passed
+- [ ] Security testing passed
+
+### Phase 5 (Production)
+
+- [ ] Staging validation successful
+- [ ] Production migration successful
+- [ ] Zero service interruptions
+- [ ] Performance targets met
+- [ ] Error rates < 0.1%
+- [ ] All monitors green
+- [ ] Positive user feedback
+
+---
+
+## Risk Mitigation
+
+### Technical Risks
+
+**Risk 1: Encryption Key Exposure**
+
+- **Impact:** Critical - All credentials compromised
+- **Mitigation:**
+  - Store key in secrets manager (AWS Secrets Manager, Vault)
+  - Never commit to version control
+  - Rotate keys periodically
+  - Audit key access logs
+
+**Risk 2: Database Performance Degradation**
+
+- **Impact:** High - Slow authentication
+- **Mitigation:**
+  - Comprehensive indexes on query patterns
+  - Connection pooling (20 connections)
+  - Query result caching
+  - Regular ANALYZE operations
+  - Monitor slow query log
+
+**Risk 3: Migration Data Corruption**
+
+- **Impact:** Critical - Lost credentials
+- **Mitigation:**
+  - Transaction-based migrations with rollback
+  - Verification steps after each operation
+  - Keep filesystem as backup during transition
+  - Test migrations on staging first
+  - Database backups before migration
+
+**Risk 4: OAuth Refresh Race Conditions**
+
+- **Impact:** Medium - Duplicate refresh requests
+- **Mitigation:**
+  - Use SELECT FOR UPDATE for row locking
+  - Implement refresh deduplication
+  - Handle lock timeout gracefully
+  - Monitor concurrent refresh attempts
+
+**Risk 5: Feature Flag Misconfiguration**
+
+- **Impact:** High - Wrong credential source
+- **Mitigation:**
+  - Safe default (filesystem mode)
+  - Clear documentation and examples
+  - Environment validation on startup
+  - Configuration audit in logs
+
+### Operational Risks
+
+**Risk 6: Insufficient Testing**
+
+- **Impact:** High - Production issues
+- **Mitigation:**
+  - Comprehensive test suite (unit, integration, E2E)
+  - Staging validation before production
+  - Gradual rollout with monitoring
+  - Canary deployments
+
+**Risk 7: Poor Documentation**
+
+- **Impact:** Medium - Operational confusion
+- **Mitigation:**
+  - Complete ADR with decision rationale
+  - Environment variable documentation
+  - Migration guide with examples
+  - Troubleshooting runbook
+  - Dashboard user guide
+
+**Risk 8: Monitoring Gaps**
+
+- **Impact:** Medium - Delayed incident detection
+- **Mitigation:**
+  - Comprehensive metrics (performance, errors, usage)
+  - Alert thresholds based on baseline
+  - Dashboard for real-time monitoring
+  - On-call runbook with procedures
+
+---
+
+## Future Enhancements
+
+### Potential Improvements (Not Planned Yet)
+
+1. **Multi-Region Support**
+   - Replicate credentials across regions
+   - Read replicas for low latency
+   - Automatic failover
+
+2. **Credential Rotation Automation**
+   - Scheduled rotation workflows
+   - Zero-downtime credential updates
+   - Automatic API key regeneration
+
+3. **Advanced Audit Logging**
+   - Detailed access logs
+   - Change history with diffs
+   - Compliance reporting
+
+4. **External Secret Manager Integration**
+   - Native support for AWS Secrets Manager
+   - HashiCorp Vault integration
+   - Azure Key Vault support
+
+5. **Row-Level Security**
+   - Multi-tenant isolation
+   - Per-user access controls
+   - Policy-based permissions
+
+6. **Credential Health Monitoring**
+   - OAuth expiry alerts
+   - API key usage tracking
+   - Automatic health checks
+
+7. **Bulk Operations**
+   - Batch account creation
+   - CSV import/export
+   - Template-based provisioning
+
+---
+
+## Conclusion
+
+The train-id and credential management migration to database is a multi-phase project that will significantly improve the scalability, security, and manageability of the proxy system.
+
+**Current Status:** Phase 1 (Foundation) is complete with PR #144 merged.
+
+**Next Immediate Steps:**
+
+1. Implement repository layer (Phase 2)
+2. Create dashboard UI (Phase 3)
+3. Comprehensive testing (Phase 4)
+4. Production rollout (Phase 5)
+
+**Timeline Estimate:**
+
+- Phase 2: 1-2 weeks
+- Phase 3: 2-3 weeks
+- Phase 4: 1 week
+- Phase 5: 1 week (gradual rollout)
+
+**Total:** 5-7 weeks to full production deployment
+
+**Success Criteria:**
+
+- Zero service interruptions
+- < 100ms p99 credential lookup latency
+- All security requirements met
+- Dashboard fully functional
+- Complete documentation
+
+This roadmap provides a comprehensive guide for completing the migration with minimal risk and maximum benefit to the system.

--- a/docs/06-Reference/environment-vars.md
+++ b/docs/06-Reference/environment-vars.md
@@ -26,6 +26,27 @@ DATABASE_URL=postgresql://user:password@localhost:5432/claude_nexus
 | `TRAIN_CLIENT_KEYS_DIR` | Directory containing per-train client API key lists (`*.client-keys.json`) | `credentials/train-client-keys` | ❌       |
 | `DEFAULT_TRAIN_ID`      | Fallback identifier when a request omits `MSL-Train-Id`                    | `default`                       | ❌       |
 
+### Credential Management (ADR-026)
+
+| Variable                    | Description                                                                 | Default | Required                              |
+| --------------------------- | --------------------------------------------------------------------------- | ------- | ------------------------------------- |
+| `USE_DATABASE_CREDENTIALS`  | Enable database-backed credential storage (feature flag)                    | `false` | ❌                                    |
+| `CREDENTIAL_ENCRYPTION_KEY` | Encryption key for storing credentials (AES-256-GCM, minimum 32 characters) | -       | ✅ (if USE_DATABASE_CREDENTIALS=true) |
+
+**Security Notes:**
+
+- The encryption key should be at least 32 characters for AES-256 security
+- Use a secrets manager (AWS Secrets Manager, HashiCorp Vault) in production
+- Never commit the encryption key to version control
+- Rotate keys periodically (requires re-encryption migration)
+
+Example:
+
+```bash
+USE_DATABASE_CREDENTIALS=false  # Safe default - uses filesystem
+CREDENTIAL_ENCRYPTION_KEY=your-secure-random-32plus-character-key-here
+```
+
 ### Train Identification
 
 | Variable                   | Description                                                                                                           | Default | Required |

--- a/packages/shared/src/config/index.ts
+++ b/packages/shared/src/config/index.ts
@@ -89,6 +89,16 @@ export const config = {
     },
   },
 
+  // Credential management (ADR-026)
+  credentials: {
+    get useDatabaseStorage() {
+      return env.bool('USE_DATABASE_CREDENTIALS', false)
+    },
+    get encryptionKey() {
+      return env.string('CREDENTIAL_ENCRYPTION_KEY', '')
+    },
+  },
+
   // Database configuration
   database: {
     get url() {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -111,3 +111,12 @@ export {
   type Message,
   type GeminiContent,
 } from './prompts/index.js'
+
+// Export credential management types and utilities (ADR-026)
+export {
+  type DatabaseAccount,
+  type DatabaseTrain,
+  type TrainAccountMapping,
+  type DecryptedAccount,
+} from './types/credentials.js'
+export { encrypt, decrypt, hashApiKey, verifyApiKeyHash } from './utils/encryption.js'

--- a/packages/shared/src/types/credentials.ts
+++ b/packages/shared/src/types/credentials.ts
@@ -1,0 +1,58 @@
+/**
+ * Database-backed credential types
+ *
+ * These types represent accounts and trains stored in the database
+ * as per ADR-026: Database Credential Management
+ */
+
+export interface DatabaseAccount {
+  accountId: string
+  accountName: string
+  credentialType: 'api_key' | 'oauth'
+  apiKeyEncrypted?: string
+  oauthAccessTokenEncrypted?: string
+  oauthRefreshTokenEncrypted?: string
+  oauthExpiresAt?: number
+  oauthScopes?: string[]
+  oauthIsMax?: boolean
+  isActive: boolean
+  createdAt: Date
+  updatedAt: Date
+  lastUsedAt?: Date
+}
+
+export interface DatabaseTrain {
+  trainId: string
+  trainName?: string
+  description?: string
+  clientApiKeysHashed?: string[]
+  slackConfig?: Record<string, unknown>
+  defaultAccountId?: string
+  isActive: boolean
+  createdAt: Date
+  updatedAt: Date
+}
+
+export interface TrainAccountMapping {
+  trainId: string
+  accountId: string
+  priority: number
+  createdAt: Date
+}
+
+/**
+ * Decrypted account for use in application logic
+ */
+export interface DecryptedAccount {
+  accountId: string
+  accountName: string
+  credentialType: 'api_key' | 'oauth'
+  apiKey?: string
+  oauthAccessToken?: string
+  oauthRefreshToken?: string
+  oauthExpiresAt?: number
+  oauthScopes?: string[]
+  oauthIsMax?: boolean
+  isActive: boolean
+  lastUsedAt?: Date
+}

--- a/packages/shared/src/utils/encryption.ts
+++ b/packages/shared/src/utils/encryption.ts
@@ -1,0 +1,91 @@
+/**
+ * Encryption utilities for credential storage
+ *
+ * Uses AES-256-GCM authenticated encryption with PBKDF2 key derivation
+ * Format: salt:iv:authTag:ciphertext (all base64-encoded)
+ */
+
+import crypto from 'crypto'
+
+const ALGORITHM = 'aes-256-gcm'
+const IV_LENGTH = 16
+const SALT_LENGTH = 32
+const KEY_ITERATIONS = 100000
+
+/**
+ * Encrypt plaintext using AES-256-GCM
+ *
+ * @param plaintext - The text to encrypt
+ * @param key - The encryption key (should be at least 32 characters)
+ * @returns Base64-encoded encrypted string with format: salt:iv:authTag:ciphertext
+ */
+export function encrypt(plaintext: string, key: string): string {
+  if (!key || key.length < 32) {
+    throw new Error('Encryption key must be at least 32 characters')
+  }
+
+  const salt = crypto.randomBytes(SALT_LENGTH)
+  const derivedKey = crypto.pbkdf2Sync(key, salt, KEY_ITERATIONS, 32, 'sha256')
+  const iv = crypto.randomBytes(IV_LENGTH)
+  const cipher = crypto.createCipheriv(ALGORITHM, derivedKey, iv)
+
+  const encrypted = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()])
+  const authTag = cipher.getAuthTag()
+
+  // Format: salt:iv:authTag:ciphertext (all base64)
+  return [salt, iv, authTag, encrypted].map(b => b.toString('base64')).join(':')
+}
+
+/**
+ * Decrypt ciphertext using AES-256-GCM
+ *
+ * @param ciphertext - The encrypted string (format: salt:iv:authTag:ciphertext)
+ * @param key - The encryption key used to encrypt
+ * @returns Decrypted plaintext
+ */
+export function decrypt(ciphertext: string, key: string): string {
+  if (!key || key.length < 32) {
+    throw new Error('Encryption key must be at least 32 characters')
+  }
+
+  const parts = ciphertext.split(':')
+  if (parts.length !== 4) {
+    throw new Error('Invalid ciphertext format')
+  }
+
+  const [saltB64, ivB64, authTagB64, encryptedB64] = parts
+
+  const salt = Buffer.from(saltB64, 'base64')
+  const iv = Buffer.from(ivB64, 'base64')
+  const authTag = Buffer.from(authTagB64, 'base64')
+  const encrypted = Buffer.from(encryptedB64, 'base64')
+
+  const derivedKey = crypto.pbkdf2Sync(key, salt, KEY_ITERATIONS, 32, 'sha256')
+  const decipher = crypto.createDecipheriv(ALGORITHM, derivedKey, iv)
+  decipher.setAuthTag(authTag)
+
+  return Buffer.concat([decipher.update(encrypted), decipher.final()]).toString('utf8')
+}
+
+/**
+ * Hash an API key using SHA-256
+ *
+ * Used for storing client API keys in a non-reversible format
+ *
+ * @param apiKey - The API key to hash
+ * @returns Hex-encoded SHA-256 hash
+ */
+export function hashApiKey(apiKey: string): string {
+  return crypto.createHash('sha256').update(apiKey).digest('hex')
+}
+
+/**
+ * Verify an API key against a hash
+ *
+ * @param apiKey - The API key to verify
+ * @param hash - The hash to compare against
+ * @returns True if the API key matches the hash
+ */
+export function verifyApiKeyHash(apiKey: string, hash: string): boolean {
+  return hashApiKey(apiKey) === hash
+}

--- a/scripts/db/migrations/013-accounts-trains-schema.ts
+++ b/scripts/db/migrations/013-accounts-trains-schema.ts
@@ -1,0 +1,180 @@
+#!/usr/bin/env bun
+import { Pool } from 'pg'
+
+/**
+ * Migration 013: Create accounts and trains tables for database-backed credential management
+ *
+ * This migration creates the schema for storing account credentials and train configurations
+ * in the database instead of filesystem files. Follows ADR-026.
+ */
+async function migrateAccountsTrainsSchema() {
+  const pool = new Pool({ connectionString: process.env.DATABASE_URL })
+
+  try {
+    await pool.query('BEGIN')
+
+    console.log('Creating accounts table...')
+    await pool.query(`
+      CREATE TABLE IF NOT EXISTS accounts (
+        account_id VARCHAR(255) PRIMARY KEY,
+        account_name VARCHAR(255) UNIQUE NOT NULL,
+        credential_type VARCHAR(20) NOT NULL CHECK (credential_type IN ('api_key', 'oauth')),
+
+        -- Encrypted credentials (base64-encoded ciphertext)
+        api_key_encrypted TEXT,
+        oauth_access_token_encrypted TEXT,
+        oauth_refresh_token_encrypted TEXT,
+        oauth_expires_at BIGINT,
+        oauth_scopes TEXT[],
+        oauth_is_max BOOLEAN DEFAULT false,
+
+        -- Audit and metadata
+        is_active BOOLEAN DEFAULT true,
+        created_at TIMESTAMPTZ DEFAULT NOW(),
+        updated_at TIMESTAMPTZ DEFAULT NOW(),
+        last_used_at TIMESTAMPTZ,
+
+        -- Constraint: ensure proper credentials based on type
+        CONSTRAINT api_key_required CHECK (
+          (credential_type = 'api_key' AND api_key_encrypted IS NOT NULL) OR
+          (credential_type = 'oauth' AND oauth_access_token_encrypted IS NOT NULL AND oauth_refresh_token_encrypted IS NOT NULL)
+        )
+      )
+    `)
+
+    console.log('Creating trains table...')
+    await pool.query(`
+      CREATE TABLE IF NOT EXISTS trains (
+        train_id VARCHAR(255) PRIMARY KEY,
+        train_name VARCHAR(255),
+        description TEXT,
+
+        -- Client API keys (SHA-256 hashed for security)
+        client_api_keys_hashed TEXT[],
+
+        -- Slack configuration (moved from accounts - per train)
+        slack_config JSONB,
+
+        -- Configuration
+        default_account_id VARCHAR(255),
+        is_active BOOLEAN DEFAULT true,
+
+        -- Audit
+        created_at TIMESTAMPTZ DEFAULT NOW(),
+        updated_at TIMESTAMPTZ DEFAULT NOW(),
+
+        -- Foreign key to accounts (nullable - can be set later)
+        CONSTRAINT fk_default_account FOREIGN KEY (default_account_id)
+          REFERENCES accounts(account_id) ON DELETE SET NULL
+      )
+    `)
+
+    console.log('Creating train_account_mappings table...')
+    await pool.query(`
+      CREATE TABLE IF NOT EXISTS train_account_mappings (
+        train_id VARCHAR(255) NOT NULL,
+        account_id VARCHAR(255) NOT NULL,
+        priority INTEGER DEFAULT 0,
+        created_at TIMESTAMPTZ DEFAULT NOW(),
+
+        PRIMARY KEY (train_id, account_id),
+
+        CONSTRAINT fk_mapping_train FOREIGN KEY (train_id)
+          REFERENCES trains(train_id) ON DELETE CASCADE,
+        CONSTRAINT fk_mapping_account FOREIGN KEY (account_id)
+          REFERENCES accounts(account_id) ON DELETE CASCADE
+      )
+    `)
+
+    console.log('Creating indexes...')
+
+    // Accounts indexes
+    await pool.query(`
+      CREATE INDEX IF NOT EXISTS idx_accounts_type
+      ON accounts(credential_type)
+    `)
+
+    await pool.query(`
+      CREATE INDEX IF NOT EXISTS idx_accounts_active
+      ON accounts(is_active)
+      WHERE is_active = true
+    `)
+
+    await pool.query(`
+      CREATE INDEX IF NOT EXISTS idx_accounts_last_used
+      ON accounts(last_used_at DESC NULLS LAST)
+    `)
+
+    // Trains indexes
+    await pool.query(`
+      CREATE INDEX IF NOT EXISTS idx_trains_active
+      ON trains(is_active)
+      WHERE is_active = true
+    `)
+
+    await pool.query(`
+      CREATE INDEX IF NOT EXISTS idx_trains_default_account
+      ON trains(default_account_id)
+      WHERE default_account_id IS NOT NULL
+    `)
+
+    // Train-account mappings indexes
+    await pool.query(`
+      CREATE INDEX IF NOT EXISTS idx_train_mappings_train
+      ON train_account_mappings(train_id)
+    `)
+
+    await pool.query(`
+      CREATE INDEX IF NOT EXISTS idx_train_mappings_account
+      ON train_account_mappings(account_id)
+    `)
+
+    await pool.query(`
+      CREATE INDEX IF NOT EXISTS idx_train_mappings_priority
+      ON train_account_mappings(train_id, priority)
+    `)
+
+    console.log('Verifying table creation...')
+    const tableCheck = await pool.query(`
+      SELECT table_name
+      FROM information_schema.tables
+      WHERE table_schema = 'public'
+      AND table_name IN ('accounts', 'trains', 'train_account_mappings')
+      ORDER BY table_name
+    `)
+
+    const expectedTables = ['accounts', 'train_account_mappings', 'trains']
+    const foundTables = tableCheck.rows.map(row => row.table_name)
+
+    if (foundTables.length !== expectedTables.length) {
+      throw new Error(
+        `Expected ${expectedTables.length} tables but found ${foundTables.length}: ${foundTables.join(', ')}`
+      )
+    }
+
+    console.log(`✓ All tables created successfully: ${foundTables.join(', ')}`)
+
+    // Verify indexes
+    const indexCheck = await pool.query(`
+      SELECT indexname
+      FROM pg_indexes
+      WHERE schemaname = 'public'
+      AND tablename IN ('accounts', 'trains', 'train_account_mappings')
+      AND indexname LIKE 'idx_%'
+      ORDER BY indexname
+    `)
+
+    console.log(`✓ Created ${indexCheck.rows.length} indexes`)
+
+    await pool.query('COMMIT')
+    console.log('Migration 013 completed successfully!')
+  } catch (error) {
+    await pool.query('ROLLBACK')
+    console.error('Migration 013 failed:', error)
+    process.exit(1)
+  } finally {
+    await pool.end()
+  }
+}
+
+migrateAccountsTrainsSchema().catch(console.error)

--- a/scripts/db/migrations/014-import-credentials-data.ts
+++ b/scripts/db/migrations/014-import-credentials-data.ts
@@ -1,0 +1,216 @@
+#!/usr/bin/env bun
+import { Pool } from 'pg'
+import { readdir, readFile } from 'fs/promises'
+import { join } from 'path'
+import { encrypt, hashApiKey } from '../../packages/shared/src/utils/encryption'
+
+/**
+ * Migration 014: Import credentials from filesystem to database
+ *
+ * This migration reads existing credential files from the filesystem and imports them
+ * into the database. It's idempotent and can be run multiple times safely.
+ *
+ * Requires: CREDENTIAL_ENCRYPTION_KEY environment variable
+ */
+
+interface ClaudeCredentials {
+  type: 'api_key' | 'oauth'
+  accountId?: string
+  api_key?: string
+  oauth?: {
+    accessToken: string
+    refreshToken: string
+    expiresAt: number
+    scopes: string[]
+    isMax: boolean
+  }
+}
+
+interface TrainClientKeys {
+  keys: string[]
+}
+
+async function migrateCredentialsData() {
+  const pool = new Pool({ connectionString: process.env.DATABASE_URL })
+  const encryptionKey = process.env.CREDENTIAL_ENCRYPTION_KEY
+
+  if (!encryptionKey || encryptionKey.length < 32) {
+    console.error('ERROR: CREDENTIAL_ENCRYPTION_KEY must be set and at least 32 characters')
+    process.exit(1)
+  }
+
+  try {
+    await pool.query('BEGIN')
+
+    const accountsDir = join(process.cwd(), 'credentials/accounts')
+    const trainsDir = join(process.cwd(), 'credentials/train-client-keys')
+
+    // Import accounts
+    console.log('Importing account credentials...')
+    let accountsImported = 0
+    let accountsSkipped = 0
+
+    try {
+      const accountFiles = await readdir(accountsDir)
+
+      for (const file of accountFiles) {
+        if (!file.endsWith('.credentials.json')) {
+          continue
+        }
+
+        const accountName = file.replace('.credentials.json', '')
+        const filePath = join(accountsDir, file)
+
+        try {
+          const content = await readFile(filePath, 'utf-8')
+          const credentials: ClaudeCredentials = JSON.parse(content)
+
+          // Generate account ID if not present
+          const accountId = credentials.accountId || `acc_${accountName}`
+
+          // Encrypt sensitive fields
+          const apiKeyEncrypted = credentials.api_key
+            ? encrypt(credentials.api_key, encryptionKey)
+            : null
+
+          const oauthAccessEncrypted = credentials.oauth?.accessToken
+            ? encrypt(credentials.oauth.accessToken, encryptionKey)
+            : null
+
+          const oauthRefreshEncrypted = credentials.oauth?.refreshToken
+            ? encrypt(credentials.oauth.refreshToken, encryptionKey)
+            : null
+
+          // Insert with ON CONFLICT for idempotency
+          const result = await pool.query(
+            `
+            INSERT INTO accounts (
+              account_id, account_name, credential_type,
+              api_key_encrypted, oauth_access_token_encrypted,
+              oauth_refresh_token_encrypted, oauth_expires_at,
+              oauth_scopes, oauth_is_max
+            ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+            ON CONFLICT (account_id) DO UPDATE SET
+              account_name = EXCLUDED.account_name,
+              credential_type = EXCLUDED.credential_type,
+              api_key_encrypted = EXCLUDED.api_key_encrypted,
+              oauth_access_token_encrypted = EXCLUDED.oauth_access_token_encrypted,
+              oauth_refresh_token_encrypted = EXCLUDED.oauth_refresh_token_encrypted,
+              oauth_expires_at = EXCLUDED.oauth_expires_at,
+              oauth_scopes = EXCLUDED.oauth_scopes,
+              oauth_is_max = EXCLUDED.oauth_is_max,
+              updated_at = NOW()
+            RETURNING (xmax = 0) AS inserted
+          `,
+            [
+              accountId,
+              accountName,
+              credentials.type,
+              apiKeyEncrypted,
+              oauthAccessEncrypted,
+              oauthRefreshEncrypted,
+              credentials.oauth?.expiresAt || null,
+              credentials.oauth?.scopes || null,
+              credentials.oauth?.isMax || false,
+            ]
+          )
+
+          if (result.rows[0].inserted) {
+            accountsImported++
+            console.log(`  ✓ Imported account: ${accountName}`)
+          } else {
+            accountsSkipped++
+            console.log(`  → Updated account: ${accountName}`)
+          }
+        } catch (error) {
+          console.error(`  ✗ Failed to import ${file}:`, error)
+        }
+      }
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+        console.log('  No accounts directory found, skipping...')
+      } else {
+        throw error
+      }
+    }
+
+    // Import trains
+    console.log('\nImporting train configurations...')
+    let trainsImported = 0
+    let trainsSkipped = 0
+
+    try {
+      const trainFiles = await readdir(trainsDir)
+
+      for (const file of trainFiles) {
+        if (!file.endsWith('.client-keys.json')) {
+          continue
+        }
+
+        const trainId = file.replace('.client-keys.json', '')
+        const filePath = join(trainsDir, file)
+
+        try {
+          const content = await readFile(filePath, 'utf-8')
+          const config: TrainClientKeys = JSON.parse(content)
+
+          // Hash client API keys for storage
+          const hashedKeys = config.keys.map(key => hashApiKey(key))
+
+          // Insert with ON CONFLICT for idempotency
+          const result = await pool.query(
+            `
+            INSERT INTO trains (train_id, client_api_keys_hashed)
+            VALUES ($1, $2)
+            ON CONFLICT (train_id) DO UPDATE SET
+              client_api_keys_hashed = EXCLUDED.client_api_keys_hashed,
+              updated_at = NOW()
+            RETURNING (xmax = 0) AS inserted
+          `,
+            [trainId, hashedKeys]
+          )
+
+          if (result.rows[0].inserted) {
+            trainsImported++
+            console.log(`  ✓ Imported train: ${trainId} (${config.keys.length} keys)`)
+          } else {
+            trainsSkipped++
+            console.log(`  → Updated train: ${trainId} (${config.keys.length} keys)`)
+          }
+        } catch (error) {
+          console.error(`  ✗ Failed to import ${file}:`, error)
+        }
+      }
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+        console.log('  No trains directory found, skipping...')
+      } else {
+        throw error
+      }
+    }
+
+    // Verify import
+    console.log('\nVerifying data import...')
+    const accountCount = await pool.query('SELECT COUNT(*) as count FROM accounts')
+    const trainCount = await pool.query('SELECT COUNT(*) as count FROM trains')
+
+    console.log(`\nSummary:`)
+    console.log(
+      `  Accounts: ${accountCount.rows[0].count} total (${accountsImported} new, ${accountsSkipped} updated)`
+    )
+    console.log(
+      `  Trains: ${trainCount.rows[0].count} total (${trainsImported} new, ${trainsSkipped} updated)`
+    )
+
+    await pool.query('COMMIT')
+    console.log('\nMigration 014 completed successfully!')
+  } catch (error) {
+    await pool.query('ROLLBACK')
+    console.error('Migration 014 failed:', error)
+    process.exit(1)
+  } finally {
+    await pool.end()
+  }
+}
+
+migrateCredentialsData().catch(console.error)

--- a/scripts/db/migrations/014-import-credentials-data.ts
+++ b/scripts/db/migrations/014-import-credentials-data.ts
@@ -2,7 +2,7 @@
 import { Pool } from 'pg'
 import { readdir, readFile } from 'fs/promises'
 import { join } from 'path'
-import { encrypt, hashApiKey } from '../../packages/shared/src/utils/encryption'
+import { encrypt, hashApiKey } from '../../../packages/shared/src/utils/encryption'
 
 /**
  * Migration 014: Import credentials from filesystem to database

--- a/services/proxy/src/container.ts
+++ b/services/proxy/src/container.ts
@@ -14,6 +14,9 @@ import { PromptRegistryService } from './mcp/PromptRegistryService.js'
 import { GitHubSyncService } from './mcp/GitHubSyncService.js'
 import { SyncScheduler } from './mcp/SyncScheduler.js'
 import { JsonRpcHandler } from './mcp/JsonRpcHandler.js'
+import { createRepositories } from './repositories/create-repositories.js'
+import type { IAccountRepository } from './repositories/IAccountRepository.js'
+import type { ITrainRepository } from './repositories/ITrainRepository.js'
 
 /**
  * Dependency injection container for the proxy service
@@ -24,6 +27,8 @@ class Container {
   private tokenUsageService?: TokenUsageService
   private metricsService?: MetricsService
   private notificationService?: NotificationService
+  private accountRepository?: IAccountRepository
+  private trainRepository?: ITrainRepository
   private authenticationService?: AuthenticationService
   private claudeApiClient?: ClaudeApiClient
   private proxyService?: ProxyService
@@ -108,6 +113,15 @@ class Container {
       }
     }
 
+    // Initialize repositories
+    const repositories = createRepositories(
+      this.pool,
+      config.auth.accountsDir,
+      config.auth.clientKeysDir
+    )
+    this.accountRepository = repositories.accountRepository
+    this.trainRepository = repositories.trainRepository
+
     // Initialize services
     this.metricsService = new MetricsService(
       {
@@ -124,6 +138,8 @@ class Container {
       defaultApiKey: undefined,
       accountsDir: config.auth.accountsDir,
       clientKeysDir: config.auth.clientKeysDir,
+      accountRepository: this.accountRepository,
+      trainRepository: this.trainRepository,
     })
     this.claudeApiClient = new ClaudeApiClient({
       baseUrl: config.api.claudeBaseUrl,
@@ -199,6 +215,20 @@ class Container {
     return this.notificationService
   }
 
+  getAccountRepository(): IAccountRepository {
+    if (!this.accountRepository) {
+      throw new Error('AccountRepository not initialized')
+    }
+    return this.accountRepository
+  }
+
+  getTrainRepository(): ITrainRepository {
+    if (!this.trainRepository) {
+      throw new Error('TrainRepository not initialized')
+    }
+    return this.trainRepository
+  }
+
   getAuthenticationService(): AuthenticationService {
     if (!this.authenticationService) {
       throw new Error('AuthenticationService not initialized')
@@ -266,6 +296,8 @@ class Container {
     this.tokenUsageService = undefined
     this.metricsService = undefined
     this.notificationService = undefined
+    this.accountRepository = undefined
+    this.trainRepository = undefined
     this.authenticationService = undefined
     this.claudeApiClient = undefined
     this.proxyService = undefined
@@ -310,6 +342,14 @@ class LazyContainer {
 
   getNotificationService(): NotificationService {
     return this.ensureInstance().getNotificationService()
+  }
+
+  getAccountRepository(): IAccountRepository {
+    return this.ensureInstance().getAccountRepository()
+  }
+
+  getTrainRepository(): ITrainRepository {
+    return this.ensureInstance().getTrainRepository()
   }
 
   getAuthenticationService(): AuthenticationService {

--- a/services/proxy/src/repositories/DatabaseAccountRepository.ts
+++ b/services/proxy/src/repositories/DatabaseAccountRepository.ts
@@ -1,0 +1,262 @@
+import { Pool } from 'pg'
+import { DecryptedAccount, DatabaseAccount, AuthenticationError } from '@agent-prompttrain/shared'
+import { encrypt, decrypt } from '@agent-prompttrain/shared/utils/encryption'
+import { IAccountRepository } from './IAccountRepository'
+import { logger } from '../middleware/logger'
+
+/**
+ * Database-based implementation of IAccountRepository.
+ *
+ * Stores credentials in PostgreSQL with AES-256-GCM encryption.
+ * Uses row-level locking (SELECT FOR UPDATE) for concurrency-safe OAuth refresh.
+ */
+export class DatabaseAccountRepository implements IAccountRepository {
+  constructor(
+    private readonly db: Pool,
+    private readonly encryptionKey: string
+  ) {
+    if (!encryptionKey || encryptionKey.length < 32) {
+      throw new Error('CREDENTIAL_ENCRYPTION_KEY must be at least 32 characters')
+    }
+  }
+
+  async listAccountNames(): Promise<string[]> {
+    try {
+      const result = await this.db.query<{ account_name: string }>(
+        'SELECT account_name FROM accounts WHERE is_active = true ORDER BY account_name'
+      )
+      return result.rows.map(row => row.account_name)
+    } catch (error) {
+      logger.error('Failed to list account names from database', {
+        metadata: {
+          error: error instanceof Error ? error.message : String(error),
+        },
+      })
+      throw error
+    }
+  }
+
+  async getAccountByName(accountName: string): Promise<DecryptedAccount | null> {
+    try {
+      const result = await this.db.query<{
+        account_id: string
+        account_name: string
+        credential_type: 'api_key' | 'oauth'
+        api_key_encrypted?: string
+        oauth_access_token_encrypted?: string
+        oauth_refresh_token_encrypted?: string
+        oauth_expires_at?: number
+        oauth_scopes?: string[]
+        oauth_is_max?: boolean
+        is_active: boolean
+        last_used_at?: Date
+      }>(
+        `SELECT account_id, account_name, credential_type,
+                api_key_encrypted, oauth_access_token_encrypted,
+                oauth_refresh_token_encrypted, oauth_expires_at,
+                oauth_scopes, oauth_is_max, is_active,
+                created_at, updated_at, last_used_at
+         FROM accounts
+         WHERE account_name = $1 AND is_active = true`,
+        [accountName]
+      )
+
+      if (result.rowCount === 0) {
+        return null
+      }
+
+      return this.decryptAccount(result.rows[0])
+    } catch (error) {
+      logger.error('Failed to get account from database', {
+        metadata: {
+          accountName,
+          error: error instanceof Error ? error.message : String(error),
+        },
+      })
+      throw error
+    }
+  }
+
+  async getApiKey(accountName: string): Promise<string | null> {
+    const account = await this.getAccountByName(accountName)
+    if (!account) {
+      return null
+    }
+
+    if (account.credentialType === 'api_key') {
+      return account.apiKey || null
+    }
+
+    if (account.credentialType === 'oauth') {
+      // Check if token needs refresh (1 minute buffer)
+      if (account.oauthExpiresAt && Date.now() >= account.oauthExpiresAt - 60000) {
+        logger.debug('OAuth token expired, needs refresh', {
+          metadata: {
+            accountName,
+            expiresAt: new Date(account.oauthExpiresAt).toISOString(),
+          },
+        })
+        // Return null to trigger refresh in CredentialManager
+        return null
+      }
+
+      return account.oauthAccessToken || null
+    }
+
+    return null
+  }
+
+  async updateOAuthTokens(
+    accountName: string,
+    tokens: {
+      accessToken: string
+      refreshToken?: string
+      expiresAt: number
+      scopes?: string[]
+      isMax?: boolean
+    }
+  ): Promise<void> {
+    const client = await this.db.connect()
+
+    try {
+      await client.query('BEGIN')
+
+      // Lock the row to prevent concurrent updates
+      const selectResult = await client.query<DatabaseAccount>(
+        `SELECT account_id, account_name, credential_type
+         FROM accounts
+         WHERE account_name = $1 AND is_active = true
+         FOR UPDATE`,
+        [accountName]
+      )
+
+      if (selectResult.rowCount === 0) {
+        throw new AuthenticationError('Account not found for OAuth token update', {
+          account: accountName,
+          hint: `Account ${accountName} does not exist or is inactive`,
+        })
+      }
+
+      const account = selectResult.rows[0]
+      if (account.credentialType !== 'oauth') {
+        throw new AuthenticationError('Cannot update OAuth tokens for non-OAuth account', {
+          account: accountName,
+        })
+      }
+
+      // Encrypt new tokens
+      const encryptedAccessToken = encrypt(tokens.accessToken, this.encryptionKey)
+      const encryptedRefreshToken = tokens.refreshToken
+        ? encrypt(tokens.refreshToken, this.encryptionKey)
+        : null
+
+      // Update the account
+      await client.query(
+        `UPDATE accounts
+         SET oauth_access_token_encrypted = $1,
+             oauth_refresh_token_encrypted = COALESCE($2, oauth_refresh_token_encrypted),
+             oauth_expires_at = $3,
+             oauth_scopes = $4,
+             oauth_is_max = $5,
+             updated_at = NOW()
+         WHERE account_name = $6`,
+        [
+          encryptedAccessToken,
+          encryptedRefreshToken,
+          tokens.expiresAt,
+          tokens.scopes || null,
+          tokens.isMax !== undefined ? tokens.isMax : null,
+          accountName,
+        ]
+      )
+
+      await client.query('COMMIT')
+
+      logger.info('OAuth tokens updated successfully', {
+        metadata: {
+          accountName,
+          expiresAt: new Date(tokens.expiresAt).toISOString(),
+        },
+      })
+    } catch (error) {
+      await client.query('ROLLBACK')
+      logger.error('Failed to update OAuth tokens', {
+        metadata: {
+          accountName,
+          error: error instanceof Error ? error.message : String(error),
+        },
+      })
+      throw error
+    } finally {
+      client.release()
+    }
+  }
+
+  async updateLastUsed(accountName: string): Promise<void> {
+    try {
+      await this.db.query(
+        'UPDATE accounts SET last_used_at = NOW() WHERE account_name = $1 AND is_active = true',
+        [accountName]
+      )
+    } catch (error) {
+      // Don't fail on last_used_at update errors
+      logger.warn('Failed to update last_used_at', {
+        metadata: {
+          accountName,
+          error: error instanceof Error ? error.message : String(error),
+        },
+      })
+    }
+  }
+
+  clearCache(): void {
+    // Database implementation doesn't cache
+    // No-op for compatibility
+  }
+
+  private decryptAccount(dbAccount: {
+    account_id: string
+    account_name: string
+    credential_type: 'api_key' | 'oauth'
+    api_key_encrypted?: string
+    oauth_access_token_encrypted?: string
+    oauth_refresh_token_encrypted?: string
+    oauth_expires_at?: number
+    oauth_scopes?: string[]
+    oauth_is_max?: boolean
+    is_active: boolean
+    last_used_at?: Date
+  }): DecryptedAccount {
+    const decrypted: DecryptedAccount = {
+      accountId: dbAccount.account_id,
+      accountName: dbAccount.account_name,
+      credentialType: dbAccount.credential_type,
+      isActive: dbAccount.is_active,
+      lastUsedAt: dbAccount.last_used_at,
+    }
+
+    if (dbAccount.credential_type === 'api_key' && dbAccount.api_key_encrypted) {
+      decrypted.apiKey = decrypt(dbAccount.api_key_encrypted, this.encryptionKey)
+    }
+
+    if (dbAccount.credential_type === 'oauth') {
+      if (dbAccount.oauth_access_token_encrypted) {
+        decrypted.oauthAccessToken = decrypt(
+          dbAccount.oauth_access_token_encrypted,
+          this.encryptionKey
+        )
+      }
+      if (dbAccount.oauth_refresh_token_encrypted) {
+        decrypted.oauthRefreshToken = decrypt(
+          dbAccount.oauth_refresh_token_encrypted,
+          this.encryptionKey
+        )
+      }
+      decrypted.oauthExpiresAt = dbAccount.oauth_expires_at
+      decrypted.oauthScopes = dbAccount.oauth_scopes
+      decrypted.oauthIsMax = dbAccount.oauth_is_max
+    }
+
+    return decrypted
+  }
+}

--- a/services/proxy/src/repositories/DatabaseAccountRepository.ts
+++ b/services/proxy/src/repositories/DatabaseAccountRepository.ts
@@ -1,5 +1,5 @@
 import { Pool } from 'pg'
-import { DecryptedAccount, DatabaseAccount, AuthenticationError } from '@agent-prompttrain/shared'
+import { DecryptedAccount, AuthenticationError } from '@agent-prompttrain/shared'
 import { encrypt, decrypt } from '@agent-prompttrain/shared/utils/encryption'
 import { IAccountRepository } from './IAccountRepository'
 import { logger } from '../middleware/logger'
@@ -122,8 +122,8 @@ export class DatabaseAccountRepository implements IAccountRepository {
       await client.query('BEGIN')
 
       // Lock the row to prevent concurrent updates
-      const selectResult = await client.query<DatabaseAccount>(
-        `SELECT account_id, account_name, credential_type
+      const selectResult = await client.query<{ credentialType: 'api_key' | 'oauth' }>(
+        `SELECT credential_type AS "credentialType"
          FROM accounts
          WHERE account_name = $1 AND is_active = true
          FOR UPDATE`,

--- a/services/proxy/src/repositories/DatabaseTrainRepository.ts
+++ b/services/proxy/src/repositories/DatabaseTrainRepository.ts
@@ -1,0 +1,113 @@
+import { Pool } from 'pg'
+import { DecryptedAccount } from '@agent-prompttrain/shared'
+import { hashApiKey } from '@agent-prompttrain/shared/utils/encryption'
+import { ITrainRepository, SlackConfig } from './ITrainRepository'
+import { DatabaseAccountRepository } from './DatabaseAccountRepository'
+import { logger } from '../middleware/logger'
+
+/**
+ * Database-based implementation of ITrainRepository.
+ *
+ * Handles train-account mappings and train configuration stored in PostgreSQL.
+ */
+export class DatabaseTrainRepository implements ITrainRepository {
+  private readonly accountRepo: DatabaseAccountRepository
+
+  constructor(
+    private readonly db: Pool,
+    encryptionKey: string
+  ) {
+    this.accountRepo = new DatabaseAccountRepository(db, encryptionKey)
+  }
+
+  async getAccountNamesForTrain(trainId: string): Promise<string[]> {
+    try {
+      const result = await this.db.query<{ account_name: string }>(
+        `SELECT a.account_name
+         FROM train_account_mappings tam
+         JOIN accounts a ON tam.account_id = a.account_id
+         WHERE tam.train_id = $1 AND a.is_active = true
+         ORDER BY tam.priority DESC, a.account_name`,
+        [trainId]
+      )
+
+      return result.rows.map(row => row.account_name)
+    } catch (error) {
+      logger.error('Failed to get account names for train', {
+        trainId,
+        error: error instanceof Error ? error.message : String(error),
+      })
+      // Return empty array on error - let authentication fall through to all accounts
+      return []
+    }
+  }
+
+  async getAccountsForTrain(trainId: string): Promise<DecryptedAccount[]> {
+    const accountNames = await this.getAccountNamesForTrain(trainId)
+
+    const accounts: DecryptedAccount[] = []
+    for (const accountName of accountNames) {
+      const account = await this.accountRepo.getAccountByName(accountName)
+      if (account) {
+        accounts.push(account)
+      }
+    }
+
+    return accounts
+  }
+
+  async validateClientKey(trainId: string, clientKey: string): Promise<boolean> {
+    try {
+      // Hash the provided key
+      const keyHash = hashApiKey(clientKey)
+
+      // Query for matching hashed key in the train's client_api_keys_hashed array
+      const result = await this.db.query<{ exists: boolean }>(
+        `SELECT EXISTS (
+          SELECT 1
+          FROM trains
+          WHERE train_id = $1
+            AND is_active = true
+            AND $2 = ANY(client_api_keys_hashed)
+        ) as exists`,
+        [trainId, keyHash]
+      )
+
+      return result.rows[0]?.exists || false
+    } catch (error) {
+      logger.error('Failed to validate client key', {
+        trainId,
+        error: error instanceof Error ? error.message : String(error),
+      })
+      return false
+    }
+  }
+
+  async getSlackConfig(trainId: string): Promise<SlackConfig | null> {
+    try {
+      const result = await this.db.query<{ slack_config: any }>(
+        'SELECT slack_config FROM trains WHERE train_id = $1 AND is_active = true',
+        [trainId]
+      )
+
+      if (result.rowCount === 0 || !result.rows[0].slack_config) {
+        return null
+      }
+
+      const config = result.rows[0].slack_config as Record<string, unknown>
+      return {
+        webhook_url: config.webhook_url as string | undefined,
+        channel: config.channel as string | undefined,
+        username: config.username as string | undefined,
+        icon_emoji: config.icon_emoji as string | undefined,
+        enabled: config.enabled !== false, // Default to enabled if not specified
+      }
+    } catch (error) {
+      logger.error('Failed to get Slack config for train', {
+        trainId,
+        error: error instanceof Error ? error.message : String(error),
+      })
+      return null
+    }
+  }
+}

--- a/services/proxy/src/repositories/DatabaseTrainRepository.ts
+++ b/services/proxy/src/repositories/DatabaseTrainRepository.ts
@@ -83,6 +83,29 @@ export class DatabaseTrainRepository implements ITrainRepository {
     }
   }
 
+  async hasClientKeys(trainId: string): Promise<boolean> {
+    try {
+      const result = await this.db.query<{ has_keys: boolean }>(
+        `SELECT COALESCE(array_length(client_api_keys_hashed, 1), 0) > 0 AS has_keys
+         FROM trains
+         WHERE train_id = $1 AND is_active = true`,
+        [trainId]
+      )
+
+      if (result.rowCount === 0) {
+        return false
+      }
+
+      return result.rows[0].has_keys
+    } catch (error) {
+      logger.error('Failed to inspect client key configuration', {
+        trainId,
+        error: error instanceof Error ? error.message : String(error),
+      })
+      return false
+    }
+  }
+
   async getSlackConfig(trainId: string): Promise<SlackConfig | null> {
     try {
       const result = await this.db.query<{ slack_config: any }>(

--- a/services/proxy/src/repositories/FilesystemAccountRepository.ts
+++ b/services/proxy/src/repositories/FilesystemAccountRepository.ts
@@ -1,0 +1,147 @@
+import { promises as fsp } from 'fs'
+import * as path from 'path'
+import { IAccountRepository } from './IAccountRepository'
+import { DecryptedAccount } from '@agent-prompttrain/shared'
+import { loadCredentials, getApiKey, ClaudeCredentials } from '../credentials'
+import { logger } from '../middleware/logger'
+
+const ACCOUNT_FILENAME_SUFFIX = '.credentials.json'
+
+/**
+ * Filesystem-based implementation of IAccountRepository.
+ *
+ * This wraps the existing credentials.ts logic to maintain
+ * 100% backward compatibility with the current filesystem-based
+ * credential management.
+ */
+export class FilesystemAccountRepository implements IAccountRepository {
+  constructor(private readonly accountsDir: string) {}
+
+  async listAccountNames(): Promise<string[]> {
+    try {
+      const entries = await fsp.readdir(this.accountsDir)
+      const names = entries
+        .filter(entry => entry.endsWith(ACCOUNT_FILENAME_SUFFIX))
+        .map(entry => entry.slice(0, -ACCOUNT_FILENAME_SUFFIX.length))
+
+      return names
+    } catch (error) {
+      const err = error as NodeJS.ErrnoException
+      if (err.code === 'ENOENT') {
+        logger.error('Accounts directory does not exist', {
+          metadata: { directory: this.accountsDir },
+        })
+        return []
+      }
+
+      logger.error('Failed to enumerate account credentials', {
+        metadata: {
+          directory: this.accountsDir,
+          error: err.message,
+        },
+      })
+      throw err
+    }
+  }
+
+  async getAccountByName(accountName: string): Promise<DecryptedAccount | null> {
+    const accountPath = this.resolveAccountPath(accountName)
+    if (!accountPath) {
+      return null
+    }
+
+    const credentials = loadCredentials(accountPath)
+    if (!credentials) {
+      return null
+    }
+
+    return this.mapToDecryptedAccount(accountName, credentials)
+  }
+
+  async getApiKey(accountName: string): Promise<string | null> {
+    const accountPath = this.resolveAccountPath(accountName)
+    if (!accountPath) {
+      return null
+    }
+
+    // Delegate to existing getApiKey function which handles OAuth refresh
+    return getApiKey(accountPath)
+  }
+
+  async updateOAuthTokens(
+    _accountName: string,
+    _tokens: {
+      accessToken: string
+      refreshToken?: string
+      expiresAt: number
+      scopes?: string[]
+      isMax?: boolean
+    }
+  ): Promise<void> {
+    // Note: The existing credentials.ts saveOAuthCredentials function
+    // is called automatically by getApiKey during refresh.
+    // This method is here for interface compatibility but is a no-op
+    // for filesystem implementation since the update happens in-place.
+  }
+
+  async updateLastUsed(_accountName: string): Promise<void> {
+    // Filesystem implementation doesn't track last_used_at
+    // This is a no-op for backward compatibility
+  }
+
+  clearCache(): void {
+    // Delegate to the global credential cache clear function
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { clearCredentialCache } = require('../credentials')
+    clearCredentialCache()
+  }
+
+  private resolveAccountPath(accountName: string): string | null {
+    const filePath = path.resolve(this.accountsDir, `${accountName}${ACCOUNT_FILENAME_SUFFIX}`)
+
+    // Basic path traversal check
+    const normalizedBase = path.resolve(this.accountsDir) + path.sep
+    const normalizedCandidate = path.resolve(filePath)
+
+    if (!normalizedCandidate.startsWith(normalizedBase)) {
+      logger.error('Path traversal attempt detected', {
+        metadata: {
+          baseDir: normalizedBase,
+          candidate: normalizedCandidate,
+        },
+      })
+      return null
+    }
+
+    return filePath
+  }
+
+  private mapToDecryptedAccount(
+    accountName: string,
+    credentials: ClaudeCredentials
+  ): DecryptedAccount {
+    if (credentials.type === 'oauth' && credentials.oauth) {
+      return {
+        accountId: credentials.accountId || accountName,
+        accountName,
+        credentialType: 'oauth',
+        oauthAccessToken: credentials.oauth.accessToken,
+        oauthRefreshToken: credentials.oauth.refreshToken,
+        oauthExpiresAt: credentials.oauth.expiresAt,
+        oauthScopes: credentials.oauth.scopes,
+        oauthIsMax: credentials.oauth.isMax,
+        isActive: true, // Filesystem accounts are always considered active
+        lastUsedAt: undefined, // Not tracked in filesystem
+      }
+    }
+
+    return {
+      accountId: credentials.accountId || accountName,
+      accountName,
+      credentialType: 'api_key',
+      apiKey: credentials.api_key,
+      isActive: true,
+      lastUsedAt: undefined,
+    }
+  }
+}

--- a/services/proxy/src/repositories/FilesystemTrainRepository.ts
+++ b/services/proxy/src/repositories/FilesystemTrainRepository.ts
@@ -1,0 +1,117 @@
+import { promises as fsp } from 'fs'
+import * as path from 'path'
+import { ITrainRepository, SlackConfig } from './ITrainRepository'
+import { DecryptedAccount } from '@agent-prompttrain/shared'
+import { logger } from '../middleware/logger'
+
+const CLIENT_KEY_FILENAME_SUFFIX = '.client-keys.json'
+const IDENTIFIER_REGEX = /^[a-zA-Z0-9._\-:]+$/
+
+/**
+ * Filesystem-based implementation of ITrainRepository.
+ *
+ * This implementation reads train client keys from the filesystem.
+ * Note: Filesystem mode does NOT support train-account mappings or Slack config.
+ * These features are only available in database mode.
+ */
+export class FilesystemTrainRepository implements ITrainRepository {
+  constructor(private readonly clientKeysDir: string) {}
+
+  async getAccountNamesForTrain(_trainId: string): Promise<string[]> {
+    // Filesystem mode doesn't have train-account mappings
+    // Return empty array - AuthenticationService will use all available accounts
+    return []
+  }
+
+  async getAccountsForTrain(_trainId: string): Promise<DecryptedAccount[]> {
+    // Filesystem mode doesn't have train-account mappings
+    // Return empty array - AuthenticationService will use all available accounts
+    return []
+  }
+
+  async validateClientKey(trainId: string, clientKey: string): Promise<boolean> {
+    const filePath = this.resolveClientKeysPath(trainId)
+    if (!filePath) {
+      return false
+    }
+
+    try {
+      const content = await fsp.readFile(filePath, 'utf-8')
+      const parsed = JSON.parse(content)
+
+      const rawKeys = Array.isArray(parsed)
+        ? parsed
+        : Array.isArray(parsed?.keys)
+          ? parsed.keys
+          : Array.isArray(parsed?.client_api_keys)
+            ? parsed.client_api_keys
+            : []
+
+      const validKeys = rawKeys
+        .filter((key: unknown) => typeof key === 'string' && key.trim().length > 0)
+        .map((key: string) => key.trim())
+
+      // In filesystem mode, keys are stored in plaintext
+      // Just check if the provided key is in the list
+      return validKeys.includes(clientKey)
+    } catch (error) {
+      const err = error as NodeJS.ErrnoException
+      if (err.code !== 'ENOENT') {
+        logger.error('Failed to read client API keys file', {
+          trainId,
+          error: err.message,
+        })
+      }
+      return false
+    }
+  }
+
+  async getSlackConfig(_trainId: string): Promise<SlackConfig | null> {
+    // Filesystem mode doesn't support Slack config at train level
+    // Slack config is stored at account level in ClaudeCredentials
+    // Return null - caller should get Slack config from account credentials
+    return null
+  }
+
+  private resolveClientKeysPath(trainId: string): string | null {
+    const sanitized = this.sanitizeIdentifier(trainId)
+    if (!sanitized) {
+      return null
+    }
+
+    const filePath = path.resolve(this.clientKeysDir, `${sanitized}${CLIENT_KEY_FILENAME_SUFFIX}`)
+
+    // Basic path traversal check
+    const normalizedBase = path.resolve(this.clientKeysDir) + path.sep
+    const normalizedCandidate = path.resolve(filePath)
+
+    if (!normalizedCandidate.startsWith(normalizedBase)) {
+      logger.error('Path traversal attempt detected', {
+        metadata: {
+          baseDir: normalizedBase,
+          candidate: normalizedCandidate,
+        },
+      })
+      return null
+    }
+
+    return filePath
+  }
+
+  private sanitizeIdentifier(value?: string | null): string | null {
+    if (!value) {
+      return null
+    }
+
+    const trimmed = value.trim()
+    if (!trimmed) {
+      return null
+    }
+
+    if (!IDENTIFIER_REGEX.test(trimmed)) {
+      return null
+    }
+
+    return trimmed
+  }
+}

--- a/services/proxy/src/repositories/IAccountRepository.ts
+++ b/services/proxy/src/repositories/IAccountRepository.ts
@@ -1,0 +1,68 @@
+import { DecryptedAccount } from '@agent-prompttrain/shared'
+
+/**
+ * Repository interface for account credential operations.
+ *
+ * Abstracts credential storage (filesystem vs database) from business logic.
+ * All methods work with account names for compatibility with existing
+ * AuthenticationService logic.
+ */
+export interface IAccountRepository {
+  /**
+   * List all available account names.
+   * Used by AuthenticationService for deterministic account selection.
+   *
+   * @returns Array of account names (not IDs)
+   */
+  listAccountNames(): Promise<string[]>
+
+  /**
+   * Get a decrypted account by its name.
+   * Handles decryption transparently for database-backed accounts.
+   *
+   * @param accountName - The account name (e.g., "my-account")
+   * @returns Decrypted account or null if not found
+   */
+  getAccountByName(accountName: string): Promise<DecryptedAccount | null>
+
+  /**
+   * Get the API key or OAuth access token for an account.
+   * Handles OAuth token refresh automatically if needed.
+   *
+   * @param accountName - The account name
+   * @returns The API key or access token, or null if unavailable
+   */
+  getApiKey(accountName: string): Promise<string | null>
+
+  /**
+   * Update OAuth credentials after token refresh.
+   * Must be concurrency-safe for database implementations (use row locking).
+   *
+   * @param accountName - The account name
+   * @param tokens - New OAuth tokens
+   */
+  updateOAuthTokens(
+    accountName: string,
+    tokens: {
+      accessToken: string
+      refreshToken?: string
+      expiresAt: number
+      scopes?: string[]
+      isMax?: boolean
+    }
+  ): Promise<void>
+
+  /**
+   * Update the last used timestamp for an account.
+   * Used for tracking account activity.
+   *
+   * @param accountName - The account name
+   */
+  updateLastUsed(accountName: string): Promise<void>
+
+  /**
+   * Clear any cached credentials.
+   * Used when credentials are updated externally.
+   */
+  clearCache(): void
+}

--- a/services/proxy/src/repositories/ITrainRepository.ts
+++ b/services/proxy/src/repositories/ITrainRepository.ts
@@ -1,0 +1,57 @@
+import { DecryptedAccount } from '@agent-prompttrain/shared'
+
+/**
+ * Slack configuration for a train.
+ * Moved from accounts to trains per ADR-026.
+ */
+export interface SlackConfig {
+  webhook_url?: string
+  channel?: string
+  username?: string
+  icon_emoji?: string
+  enabled?: boolean
+}
+
+/**
+ * Repository interface for train-specific operations.
+ *
+ * Handles train-account mappings and train configuration.
+ */
+export interface ITrainRepository {
+  /**
+   * Get all account names mapped to a specific train.
+   * Returns accounts in priority order (highest priority first).
+   *
+   * @param trainId - The train identifier
+   * @returns Array of account names in priority order
+   */
+  getAccountNamesForTrain(trainId: string): Promise<string[]>
+
+  /**
+   * Get all decrypted accounts for a train.
+   * Returns accounts in priority order for deterministic selection.
+   *
+   * @param trainId - The train identifier
+   * @returns Array of decrypted accounts in priority order
+   */
+  getAccountsForTrain(trainId: string): Promise<DecryptedAccount[]>
+
+  /**
+   * Validate a client API key for a train.
+   * Client keys are hashed (SHA-256) for security.
+   *
+   * @param trainId - The train identifier
+   * @param clientKey - The client API key to validate
+   * @returns True if the key is valid for this train
+   */
+  validateClientKey(trainId: string, clientKey: string): Promise<boolean>
+
+  /**
+   * Get the Slack configuration for a train.
+   * Returns null if Slack is not configured for this train.
+   *
+   * @param trainId - The train identifier
+   * @returns Slack configuration or null
+   */
+  getSlackConfig(trainId: string): Promise<SlackConfig | null>
+}

--- a/services/proxy/src/repositories/ITrainRepository.ts
+++ b/services/proxy/src/repositories/ITrainRepository.ts
@@ -47,6 +47,14 @@ export interface ITrainRepository {
   validateClientKey(trainId: string, clientKey: string): Promise<boolean>
 
   /**
+   * Determine whether client API keys are configured for a train.
+   *
+   * @param trainId - The train identifier
+   * @returns True if one or more keys are configured
+   */
+  hasClientKeys(trainId: string): Promise<boolean>
+
+  /**
    * Get the Slack configuration for a train.
    * Returns null if Slack is not configured for this train.
    *

--- a/services/proxy/src/repositories/create-repositories.ts
+++ b/services/proxy/src/repositories/create-repositories.ts
@@ -1,0 +1,66 @@
+import { Pool } from 'pg'
+import { config } from '@agent-prompttrain/shared/config'
+import { IAccountRepository } from './IAccountRepository'
+import { ITrainRepository } from './ITrainRepository'
+import { FilesystemAccountRepository } from './FilesystemAccountRepository'
+import { FilesystemTrainRepository } from './FilesystemTrainRepository'
+import { DatabaseAccountRepository } from './DatabaseAccountRepository'
+import { DatabaseTrainRepository } from './DatabaseTrainRepository'
+import { logger } from '../middleware/logger'
+
+export interface Repositories {
+  accountRepository: IAccountRepository
+  trainRepository: ITrainRepository
+}
+
+/**
+ * Factory function to create repository implementations based on configuration.
+ *
+ * Uses the USE_DATABASE_CREDENTIALS feature flag to switch between
+ * filesystem-based and database-based credential storage.
+ *
+ * @param dbPool - PostgreSQL connection pool (required for database mode)
+ * @param accountsDir - Directory for filesystem account credentials
+ * @param clientKeysDir - Directory for filesystem client keys
+ * @returns Repository implementations
+ */
+export function createRepositories(
+  dbPool: Pool | undefined,
+  accountsDir: string,
+  clientKeysDir: string
+): Repositories {
+  const useDatabaseStorage = config.credentials.useDatabaseStorage
+  const encryptionKey = config.credentials.encryptionKey
+
+  logger.info('Creating credential repositories', {
+    metadata: {
+      mode: useDatabaseStorage ? 'database' : 'filesystem',
+      accountsDir: useDatabaseStorage ? undefined : accountsDir,
+      clientKeysDir: useDatabaseStorage ? undefined : clientKeysDir,
+    },
+  })
+
+  if (useDatabaseStorage) {
+    // Database mode
+    if (!dbPool) {
+      throw new Error('Database pool is required when USE_DATABASE_CREDENTIALS=true')
+    }
+
+    if (!encryptionKey || encryptionKey.length < 32) {
+      throw new Error(
+        'CREDENTIAL_ENCRYPTION_KEY must be set and at least 32 characters when using database credentials'
+      )
+    }
+
+    return {
+      accountRepository: new DatabaseAccountRepository(dbPool, encryptionKey),
+      trainRepository: new DatabaseTrainRepository(dbPool, encryptionKey),
+    }
+  }
+
+  // Filesystem mode (default)
+  return {
+    accountRepository: new FilesystemAccountRepository(accountsDir),
+    trainRepository: new FilesystemTrainRepository(clientKeysDir),
+  }
+}

--- a/services/proxy/tests/client-auth.test.ts
+++ b/services/proxy/tests/client-auth.test.ts
@@ -27,6 +27,14 @@ class MockAuthenticationService extends AuthenticationService {
     return this.keyMap.get(trainId) ?? []
   }
 
+  async hasClientKeys(trainId: string): Promise<boolean> {
+    return (this.keyMap.get(trainId) ?? []).length > 0
+  }
+
+  async validateClientKey(trainId: string, clientKey: string): Promise<boolean> {
+    return (this.keyMap.get(trainId) ?? []).includes(clientKey)
+  }
+
   // authenticate is not used in these tests but must be implemented
   async authenticate(_context: RequestContext) {
     throw new Error('Not implemented in mock')


### PR DESCRIPTION
## Summary
- ensure AuthenticationService uses database repositories for accounts, trains, and slack config when ADR-026 is enabled
- move client auth checks through service helpers so database-stored hashes are validated
- correct the credential import migration and alias issues discovered in review

## Testing
- bun test services/proxy/tests/authentication-service.test.ts services/proxy/tests/client-auth.test.ts

> Based on #144