### PR TITLE
Fix credential repository integration

### DIFF
--- a/scripts/db/migrations/014-import-credentials-data.ts
+++ b/scripts/db/migrations/014-import-credentials-data.ts
@@ -2,7 +2,7 @@
 import { Pool } from 'pg'
 import { readdir, readFile } from 'fs/promises'
 import { join } from 'path'
-import { encrypt, hashApiKey } from '../../packages/shared/src/utils/encryption'
+import { encrypt, hashApiKey } from '../../../packages/shared/src/utils/encryption'
 
 /**
  * Migration 014: Import credentials from filesystem to database

--- a/services/proxy/src/repositories/DatabaseAccountRepository.ts
+++ b/services/proxy/src/repositories/DatabaseAccountRepository.ts
@@ -1,5 +1,5 @@
 import { Pool } from 'pg'
-import { DecryptedAccount, DatabaseAccount, AuthenticationError } from '@agent-prompttrain/shared'
+import { DecryptedAccount, AuthenticationError } from '@agent-prompttrain/shared'
 import { encrypt, decrypt } from '@agent-prompttrain/shared/utils/encryption'
 import { IAccountRepository } from './IAccountRepository'
 import { logger } from '../middleware/logger'
@@ -122,8 +122,8 @@ export class DatabaseAccountRepository implements IAccountRepository {
       await client.query('BEGIN')
 
       // Lock the row to prevent concurrent updates
-      const selectResult = await client.query<DatabaseAccount>(
-        `SELECT account_id, account_name, credential_type
+      const selectResult = await client.query<{ credentialType: 'api_key' | 'oauth' }>(
+        `SELECT credential_type AS "credentialType"
          FROM accounts
          WHERE account_name = $1 AND is_active = true
          FOR UPDATE`,

--- a/services/proxy/src/repositories/DatabaseTrainRepository.ts
+++ b/services/proxy/src/repositories/DatabaseTrainRepository.ts
@@ -83,6 +83,29 @@ export class DatabaseTrainRepository implements ITrainRepository {
     }
   }
 
+  async hasClientKeys(trainId: string): Promise<boolean> {
+    try {
+      const result = await this.db.query<{ has_keys: boolean }>(
+        `SELECT COALESCE(array_length(client_api_keys_hashed, 1), 0) > 0 AS has_keys
+         FROM trains
+         WHERE train_id = $1 AND is_active = true`,
+        [trainId]
+      )
+
+      if (result.rowCount === 0) {
+        return false
+      }
+
+      return result.rows[0].has_keys
+    } catch (error) {
+      logger.error('Failed to inspect client key configuration', {
+        trainId,
+        error: error instanceof Error ? error.message : String(error),
+      })
+      return false
+    }
+  }
+
   async getSlackConfig(trainId: string): Promise<SlackConfig | null> {
     try {
       const result = await this.db.query<{ slack_config: any }>(

--- a/services/proxy/src/repositories/ITrainRepository.ts
+++ b/services/proxy/src/repositories/ITrainRepository.ts
@@ -47,6 +47,14 @@ export interface ITrainRepository {
   validateClientKey(trainId: string, clientKey: string): Promise<boolean>
 
   /**
+   * Determine whether client API keys are configured for a train.
+   *
+   * @param trainId - The train identifier
+   * @returns True if one or more keys are configured
+   */
+  hasClientKeys(trainId: string): Promise<boolean>
+
+  /**
    * Get the Slack configuration for a train.
    * Returns null if Slack is not configured for this train.
    *

--- a/services/proxy/tests/client-auth.test.ts
+++ b/services/proxy/tests/client-auth.test.ts
@@ -27,6 +27,14 @@ class MockAuthenticationService extends AuthenticationService {
     return this.keyMap.get(trainId) ?? []
   }
 
+  async hasClientKeys(trainId: string): Promise<boolean> {
+    return (this.keyMap.get(trainId) ?? []).length > 0
+  }
+
+  async validateClientKey(trainId: string, clientKey: string): Promise<boolean> {
+    return (this.keyMap.get(trainId) ?? []).includes(clientKey)
+  }
+
   // authenticate is not used in these tests but must be implemented
   async authenticate(_context: RequestContext) {
     throw new Error('Not implemented in mock')


### PR DESCRIPTION
## Summary
- ensure AuthenticationService uses database repositories for accounts, trains, and slack config when ADR-026 is enabled
- move client auth checks through service helpers so database-stored hashes are validated
- correct the credential import migration and alias issues discovered in review

## Testing
- bun test services/proxy/tests/authentication-service.test.ts services/proxy/tests/client-auth.test.ts

> Follow-up for #144